### PR TITLE
polymorphic associations are scopeable

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -126,6 +126,19 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
 
     # polymorphic-association
 
+    content.find('[data-polymorphic-cached]').each ->
+      type_select = $(this)
+      field = type_select.parents('.control-group').first()
+      object_select = field.find('select').last()
+      type_select.on 'change', (e) ->
+        if $(this).val() is ''
+          object_select.html('<option value=""></option>')
+        else
+          html = '<option></option>'
+          $(type_select.data('collections')[type_select.val()]).each (i, el) ->
+            html += '<option value="' + el[1] + '">' + el[0] + '</option>'
+          object_select.html(html)
+
     content.find('[data-polymorphic]').each ->
       type_select = $(this)
       field = type_select.parents('.control-group').first()

--- a/app/views/rails_admin/main/_form_polymorphic_association.html.haml
+++ b/app/views/rails_admin/main/_form_polymorphic_association.html.haml
@@ -2,9 +2,17 @@
   type_collection = field.polymorphic_type_collection
   type_column = field.association[:foreign_type].to_s
   selected_type = field.bindings[:object].send(type_column)
-  collection = field.associated_collection(selected_type)
+  collections = HashWithIndifferentAccess.new
+  type_collection.map(&:last).each do |type|
+    collections[type] = field.associated_collection(type)
+  end
   selected = field.bindings[:object].send(field.association[:name])
   column_type_dom_id = form.dom_id(field).sub(field.method_name.to_s, type_column)
+  select_data_attributes = if field.associated_collection_scope.nil?
+    { :polymorphic => true, :urls => field.polymorphic_type_urls.to_json }
+  else
+    { :polymorphic_cached => true, collections: collections.to_json }
+  end
 
-= form.select type_column, type_collection, {:include_blank => true, :selected => selected_type}, :id => column_type_dom_id, :data => { :polymorphic => true, :urls => field.polymorphic_type_urls.to_json }
-= form.select field.method_name, collection, {:include_blank => true, :selected => selected.try(:id)}, :style => "margin-left:10px;"
+= form.select type_column, type_collection, {:include_blank => true, :selected => selected_type}, :id => column_type_dom_id, :data => { }.merge(select_data_attributes)
+= form.select field.method_name, collections[selected_type], {:include_blank => true, :selected => selected.try(:id)}, :style => "margin-left:10px;"

--- a/app/views/rails_admin/main/_form_polymorphic_association.html.haml
+++ b/app/views/rails_admin/main/_form_polymorphic_association.html.haml
@@ -15,4 +15,4 @@
   end
 
 = form.select type_column, type_collection, {:include_blank => true, :selected => selected_type}, :id => column_type_dom_id, :data => { }.merge(select_data_attributes)
-= form.select field.method_name, collections[selected_type], {:include_blank => true, :selected => selected.try(:id)}, :style => "margin-left:10px;"
+= form.select field.method_name, selected_type.nil? ? [] : collections[selected_type], {:include_blank => true, :selected => selected.try(:id)}, :style => "margin-left:10px;"

--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -32,7 +32,6 @@ module RailsAdmin
             false
           end
 
-          # TODO not supported yet
           register_instance_option :associated_collection_scope do
             nil
           end
@@ -44,7 +43,10 @@ module RailsAdmin
           def associated_collection(type)
             return [] if type.blank?
             config = RailsAdmin.config(type)
-            config.abstract_model.all.map do |object|
+            associated_models = config.abstract_model
+            associated_models = associated_collection_scope.call(associated_models) unless associated_collection_scope.nil?
+            associated_models = associated_models.all
+            associated_models.map do |object|
               [object.send(config.object_label_method), object.id]
             end
           end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -215,13 +215,6 @@ describe RailsAdmin::MainController do
       @comment = FactoryGirl.create :comment
       controller.params = { :associated_collection => "commentable", :current_action => "update", :source_abstract_model => 'comment', :source_object_id => @comment.id, :model_name => "player", :action => 'index' }
       controller.get_model # set @model_config for Team
-    end
-
-    it "scopes polymorphic associated records" do
-      @player = FactoryGirl.create :player, :injured => true
-      @player.comments << FactoryGirl.create(:comment)
-      @player2 = FactoryGirl.create :player, :injured => false
-      @player2.comments << FactoryGirl.create(:comment) # comment for another player
 
       RailsAdmin.config Comment do
         field :commentable do
@@ -233,6 +226,14 @@ describe RailsAdmin::MainController do
           end
         end
       end
+    end
+
+    it "scopes polymorphic associated records" do
+      @player = FactoryGirl.create :player, :injured => true
+      @player.comments << FactoryGirl.create(:comment)
+      @player2 = FactoryGirl.create :player, :injured => false
+      @player2.comments << FactoryGirl.create(:comment) # comment for another player
+
       expect(controller.list_entries.to_a).to eq([@player])
     end
   end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -228,7 +228,6 @@ describe RailsAdmin::MainController do
           associated_collection_scope do
             commentable = bindings[:object]
             Proc.new { |scope|
-              binding.pry
               scope.where(:injured => true)
             }
           end

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -691,6 +691,24 @@ describe "RailsAdmin Config DSL Edit Section" do
     end
   end
 
+  describe "scoped polymorphic form" do
+    its(:status_code) do
+      RailsAdmin.config Comment do
+        field :commentable do
+          associated_collection_scope do
+            commentable = bindings[:object]
+            Proc.new { |scope|
+              scope
+            }
+          end
+        end
+      end
+      comment = FactoryGirl.create :comment, :commentable => nil
+      visit edit_path(:model_name => "comment", :id => comment.id)
+      should == 200
+    end
+  end
+
   describe "nested form" do
     it "works" do
       @record = FactoryGirl.create :field_test


### PR DESCRIPTION
This patch enables the scope for a polymorphic association to be set (in the same way as it already works in the non polymorphic associations).
It enables caching if a scope is set.