### PR TITLE
Add navigation static links options

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -65,8 +65,11 @@ module RailsAdmin
     end
 
     def static_navigation
+      default_links_options = {:target => '_blank'}
+      links_options = default_links_options.merge RailsAdmin::Config.navigation_static_links_options
+
       li_stack = RailsAdmin::Config.navigation_static_links.map do |title, url|
-        content_tag(:li, link_to(title.to_s, url, :target => '_blank'))
+        content_tag(:li, link_to(title.to_s, url, links_options))
       end.join
 
       label = RailsAdmin::Config.navigation_static_label || t('admin.misc.navigation_static_label')

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -65,11 +65,8 @@ module RailsAdmin
     end
 
     def static_navigation
-      default_links_options = {:target => '_blank'}
-      links_options = default_links_options.merge RailsAdmin::Config.navigation_static_links_options
-
       li_stack = RailsAdmin::Config.navigation_static_links.map do |title, url|
-        content_tag(:li, link_to(title.to_s, url, links_options))
+        content_tag(:li, link_to(title.to_s, url, RailsAdmin::Config.navigation_static_links_options))
       end.join
 
       label = RailsAdmin::Config.navigation_static_label || t('admin.misc.navigation_static_label')

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -66,6 +66,7 @@ module RailsAdmin
 
       # accepts a hash of static links to be shown below the main navigation
       attr_accessor :navigation_static_links
+      attr_accessor :navigation_static_links_options
       attr_accessor :navigation_static_label
 
       # yell about fields that are not marked as accessible
@@ -291,6 +292,7 @@ module RailsAdmin
         @registry = {}
         @navigation_static_links = {}
         @navigation_static_label = nil
+        @navigation_static_links_options = ActiveSupport::HashWithIndifferentAccess.new
         RailsAdmin::Config::Actions.reset
       end
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -292,7 +292,7 @@ module RailsAdmin
         @registry = {}
         @navigation_static_links = {}
         @navigation_static_label = nil
-        @navigation_static_links_options = ActiveSupport::HashWithIndifferentAccess.new
+        @navigation_static_links_options = ActiveSupport::HashWithIndifferentAccess.new({:target => '_blank'})
         RailsAdmin::Config::Actions.reset
       end
 

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -322,6 +322,30 @@ describe RailsAdmin::ApplicationHelper do
         end
         expect(helper.static_navigation).to match /Test Header/
       end
+
+      it "sets options to static links" do
+        RailsAdmin.config do |config|
+          config.navigation_static_links = {
+            'Test Link' => 'http://www.google.com'
+          }
+          config.navigation_static_links_options = {
+            :rel => 'nofollow'
+          }
+        end
+        expect(helper.static_navigation).to match(/rel="nofollow"/)
+      end
+
+      it "overrides default links options" do
+        RailsAdmin.config do |config|
+          config.navigation_static_links = {
+            'Test Link' => 'http://www.google.com'
+          }
+          config.navigation_static_links_options = {
+            :target => nil
+          }
+        end
+        expect(helper.static_navigation).not_to match(/target="_blank"/)
+      end
     end
 
     describe "#bulk_menu" do


### PR DESCRIPTION
Added RailsAdmin::Config.navigation_static_links_options

Example usage:
```ruby
RailsAdmin.config do |config|
  config.navigation_static_links = {
    'Test Link' => 'http://www.google.com'
  }
  # will be added to all navigation static links
  config.navigation_static_links_options = {
    :rel => 'nofollow'
  }
end
```