### PR TITLE
Allow proc for static_navigation url parameter

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -66,6 +66,7 @@ module RailsAdmin
 
     def static_navigation
       li_stack = RailsAdmin::Config.navigation_static_links.map do |title, url|
+        url = url.call(self) if url.is_a?(Proc)
         content_tag(:li, link_to(title.to_s, url, :target => '_blank'))
       end.join
 


### PR DESCRIPTION
Handle a Proc vs. String as a navigation_static_link url