### PR TITLE
Allow multiple config blocks for a single resource in RailsAdmin

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -237,11 +237,9 @@ module RailsAdmin
           end
         end
 
-        if block
-          @registry[key] = RailsAdmin::Config::LazyModel.new(entity, &block)
-        else
-          @registry[key] ||= RailsAdmin::Config::LazyModel.new(entity)
-        end
+        @registry[key] ||= RailsAdmin::Config::LazyModel.new(entity)
+        @registry[key].add_deferred_block(&block) if block
+        @registry[key]
       end
 
       def default_hidden_fields=(fields)

--- a/lib/rails_admin/config/lazy_model.rb
+++ b/lib/rails_admin/config/lazy_model.rb
@@ -5,15 +5,54 @@ module RailsAdmin
     class LazyModel
       def initialize(entity, &block)
         @entity = entity
-        @deferred_block = block
+        @deferred_blocks = block ? [ block ] : []
       end
-
+      def add_deferred_block(&block)
+        @deferred_blocks << block
+      end
       def method_missing(method, *args, &block)
         if !@model
           @model = RailsAdmin::Config::Model.new(@entity)
-          @model.instance_eval(&@deferred_block) if @deferred_block
+          # Configuration defined in the model class should take precedence
+          # over configuration defined in initializers/rails_admin.rb.
+          #
+          # Due to the way the Rails initialization process works,
+          # configuration blocks found in app/models/MODEL.rb are added to
+          # @deferred_bocks before blocks defined in initializers/rails_admin.rb. 
+          # Executing blocks in the order of addition would yield unexpected
+          # behaviour, as blocks from the initializer would overwrite settings 
+          # defined in model classes.
+          #
+          # In order to maintain the expected precedence (model configuration over
+          # initializer configuration), all blocks are executed in reverse order.
+          #
+          # Given the following code containing initialization blocks:
+          #
+          #     # app/models/some_model.rb
+          #     class SomeModel
+          #       rails_admin do
+          #         :
+          #       end
+          #     end
+          #
+          #     # config/initializers/rails_admin.rb
+          #     config.model SomeModel do
+          #       :
+          #     end
+          #
+          # The block from app/models/some_model.rb will be added to
+          # @deferred_blocks in front of the one from config/initializers/rails_admin.rb.
+          # In order to give precedence to the block from SomeModel,
+          # execute blocks in reverse order.
+          #
+          # CAVEAT: if, for some reason, a model would specify multiple configuration
+          # blocks, later blocks would be executed before earlier blocks - which could
+          # result in unexpected behaviour. However (and therefore), defining multiple
+          # configuration blocks within a single model class are discouraged.
+          @deferred_blocks.flatten.reverse.each do |block|
+            @model.instance_eval(&block)
+          end
         end
-
         @model.send(method, *args, &block)
       end
     end


### PR DESCRIPTION
When using RailsAdmin within another gem, it should be possible to spread out and merge configuration blocks for a single resource across initializers and models, in an attempt to produce DRY code.

Currently, RailsAdmin allows multiple configuration blocks for a single resource, however, blocks evaluating later will overwrite earlier blocks.

This pull requests contains two small changes to `RailsAdmin::Config::LazyModel` and `RailsAdmin::Config`, to implement multiple configuration blocks for a single resource.

For example, in the current version of RailsAdmin, these two blocks would overwrite each other - depending on the exact order of loading (see comment in `lib/rails_admin/config/lazy_model.rb`) :

    # app/models/some_model.rb
    class SomeModel
      rails_admin do
        :
      end
    end

    # config/initializers/rails_admin.rb
    config.model SomeModel do
      :
    end

After applying this pull request, the settings defined in `config/initializers/rails_admin.rb` will evaluate before the ones found in `SomeModel`. The settings from `config/initializers/rails_admin.rb` will be maintained, although `SomeModel` may chose to overwrite some settings.