### PR TITLE
Disable navigation_static_label

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -68,8 +68,10 @@ module RailsAdmin
         content_tag(:li, link_to(title.to_s, url, target: '_blank'))
       end.join
 
-      label = RailsAdmin::Config.navigation_static_label || t('admin.misc.navigation_static_label')
-      li_stack = %(<li class='nav-header'>#{label}</li>#{li_stack}).html_safe if li_stack.present?
+      unless RailsAdmin::Config.disable_navigation_static_label
+        label = RailsAdmin::Config.navigation_static_label || t('admin.misc.navigation_static_label')
+        li_stack = %(<li class='nav-header'>#{label}</li>#{li_stack}).html_safe if li_stack.present?
+      end
       li_stack
     end
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -63,6 +63,9 @@ module RailsAdmin
       attr_accessor :navigation_static_links
       attr_accessor :navigation_static_label
 
+      # disables static label when true
+      attr_accessor :disable_navigation_static_label
+
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
 

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -304,7 +304,7 @@ describe RailsAdmin::ApplicationHelper do
         expect(helper.static_navigation).to match(/Test Link/)
       end
 
-      it 'shows default header if navigation_static_label not defined in config' do
+      it 'shows default header' do
         RailsAdmin.config do |config|
           config.navigation_static_links = {
             'Test Link' => 'http://www.google.com'
@@ -313,7 +313,7 @@ describe RailsAdmin::ApplicationHelper do
         expect(helper.static_navigation).to match(I18n.t('admin.misc.navigation_static_label'))
       end
 
-      it 'shows custom header if defined' do
+      it 'shows custom header' do
         RailsAdmin.config do |config|
           config.navigation_static_label = 'Test Header'
           config.navigation_static_links = {
@@ -321,6 +321,19 @@ describe RailsAdmin::ApplicationHelper do
           }
         end
         expect(helper.static_navigation).to match(/Test Header/)
+      end
+
+      context 'when disable_navigation_static_label is true' do
+        it 'does not renders navigation_static_label' do
+          RailsAdmin.config do |config|
+            config.disable_navigation_static_label = true
+            config.navigation_static_label = 'Test Header'
+            config.navigation_static_links = {
+              'Test Link' => 'http://www.google.com'
+            }
+          end
+          expect(helper.static_navigation).not_to match(/Test Header/)
+        end
       end
     end
 


### PR DESCRIPTION
Based on issue [#1665](https://github.com/sferik/rails_admin/issues/1665).
It introduces an option to RailsAdmin::Config ```disable_navigation_static_label``` that doesn't show navigation_static_label when set as true.