### PR TITLE
Add instance option 'confirmation_required' that will require that an option shows a confirmation prompt

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -117,9 +117,11 @@ module RailsAdmin
       actions = actions(parent, abstract_model, object).select { |a| a.http_methods.include?(:get) }
       actions.collect do |action|
         wording = wording_for(:menu, action)
+        confirm = action.confirmation_required ? "data-confirm=\"#{t("admin.actions.confirm_prompt")}\"" : ""
+        href = url_for(action: action.action_name, controller: 'rails_admin/main', model_name: abstract_model.try(:to_param), id: (object.try(:persisted?) && object.try(:id) || nil))
         %(
           <li title="#{wording if only_icon}" rel="#{'tooltip' if only_icon}" class="icon #{action.key}_#{parent}_link #{'active' if current_action?(action)}">
-            <a class="#{action.pjax? ? 'pjax' : ''}" href="#{url_for(action: action.action_name, controller: 'rails_admin/main', model_name: abstract_model.try(:to_param), id: (object.try(:persisted?) && object.try(:id) || nil))}">
+            <a class="#{action.pjax? ? 'pjax' : ''}" #{confirm} href="#{href}">
               <i class="#{action.link_icon}"></i>
               <span#{only_icon ? " style='display:none'" : ''}>#{wording}</span>
             </a>

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -58,6 +58,7 @@ en:
       item: "Item"
       message: "Message"
     actions:
+      confirm_prompt: "Are you sure?"
       dashboard:
         title: "Site Administration"
         menu: "Dashboard"

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -18,6 +18,11 @@ module RailsAdmin
           []
         end
 
+        # Should the action show a confirmation (using jquery_ujs) before performing this action
+        register_instance_option :confirmation_required do
+          false
+        end
+
         # http://getbootstrap.com/2.3.2/base-css.html#icons
         register_instance_option :link_icon do
           'icon-question-sign'


### PR DESCRIPTION
Hi team,

Is this feature something that you would consider incorporating into RailsAdmin? A confirmation prompt seems like something that would be commonly required - I certainly need it in the app I'm building, currently.

If you are ok with the idea of this feature, I plan to add in some specs and incorporate I18n so that you can customise the confirmation prompt per action/model.