### PR TITLE
adds optional js manifest for extending functionality via third party gems

### DIFF
--- a/app/assets/javascripts/rails_admin/plugins.js
+++ b/app/assets/javascripts/rails_admin/plugins.js
@@ -1,0 +1,5 @@
+// This is a manifest file for including custom plugins for rails admin. You
+// should override it in your application at javascripts/rails_admin/plugins.js
+// to include javascripts from other gems like:
+//
+// //= require 'rails_admin_markitup/rails_admin_markitup'

--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -6,6 +6,7 @@
     = csrf_meta_tag
     = stylesheet_link_tag "rails_admin/rails_admin.css", media: :all
     = javascript_include_tag "rails_admin/rails_admin.js"
+    = javascript_include_tag "rails_admin/plugins.js"
     -# Initialize JS simple i18n
     :javascript
       RailsAdmin.I18n.init(JSON.parse("#{j I18n.t("admin.js").to_json}"))

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -21,6 +21,7 @@ module RailsAdmin
         rails_admin/rails_admin.css
         rails_admin/jquery.colorpicker.js
         rails_admin/jquery.colorpicker.css
+        rails_admin/plugins.js
       ]
     end
 


### PR DESCRIPTION
Hi there. I wanted to extend rails_admin to add a new type of field. Specifically- though not really important to this pull request, I wanted to extend the `Text` type with markitup-rails. When I opened up rails_admin to take a look for the class I wanted to extend, and how I might go about that, I noticed there was a mess of custom extensions/plugins in the field types. To me this does not seem healthy for the project (it bloats the gem, it adds a lot of maintenance requirements for you, and it just doesn't seem like it will scale well over time), and I am not sure if I am missing something or if this was just how things were going at first.

So, I started poking around to see if it would be possible to extend rails_admin via a third-party gem of my own design. It was. While doing that, the only issue I really came up against was good way for getting javascript encapsulated in my gem into the rails_admin js manifest at run-time and in the right order. So, I added a new manifest, required it after everything, and then you can just overwrite it in your project if you want to add custom plugins that extend rails_admin.

If there is a better way to do this that I just missed, I would love to hear it.

You can see the current source code for the gem at https://github.com/Universum/rails_admin_markitup, the readme also explains how it would be implemented. It's dependent on my forked version of rails_admin right now, so I haven't released it to be bundled.

Anyway, would love to hear some thoughts/feedback.