### PR TITLE
const_defined does not work with namespaced models

### DIFF
--- a/app/views/rails_admin/main/_dashboard_history.html.haml
+++ b/app/views/rails_admin/main/_dashboard_history.html.haml
@@ -16,6 +16,6 @@
           - else
             %td= label
         - else
-          - label = Object.const_defined?(t.table) ? t.table.constantize.model_name.human : t.table
+          - label = abstract_model.try(:pretty_name) || t.table
           %td= "#{label} ##{t.item}"
         %td= t.message


### PR DESCRIPTION
If history is enabled and a namespaced model gets deleted, this throws a "wrong constant name" error message.

I added the .try just to be extra safe.