### PR TITLE
dependent_field for belongs_to

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-select.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-select.js
@@ -114,7 +114,16 @@
 
       filtering_select.append(input).append(button).insertAfter(select);
 
+      if (this.options.dependent_field_selector) {
+        self.options.dependent_field_value = $(this.options.dependent_field_selector).val();
+        $(this.options.dependent_field_selector).on('change', function () {
+          self.options.dependent_field_value = $(this).val();
 
+          input.val('');
+          select.html($('<option value="" selected="selected"></option>'));
+          select.trigger("change");
+        })
+      }
     },
 
     _getResultSet: function(request, data, xhr) {
@@ -156,9 +165,12 @@
             this.xhr.abort();
           }
 
+          data = self.options.createQuery(request.term)
+          data.dependent_field_value = self.options.dependent_field_value
+
           this.xhr = $.ajax({
             url: source,
-            data: self.options.createQuery(request.term),
+            data: data,
             dataType: "json",
             autocompleteRequest: ++requestIndex,
             success: function(data, status) {

--- a/app/views/rails_admin/main/_form_filtering_select.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_select.html.haml
@@ -20,9 +20,15 @@
 
   collection = xhr ? [[selected_name, selected_id]] : controller.list_entries(config, :index, field.associated_collection_scope, false).map { |o| [o.send(field.associated_object_label_method), o.send(field.associated_primary_key)] }
 
+  if field.dependent_field
+    dependent_field = field.parent.fields.select {|f| f.name == field.dependent_field}.first
+    dependent_field_selector = "##{source_abstract_model.to_param}_#{dependent_field.method_name}"
+  end
+
   js_data = {
     xhr: xhr,
-    remote_source: index_path(config.abstract_model.to_param, source_object_id: form.object.id, source_abstract_model: source_abstract_model.to_param, associated_collection: field.name, current_action: current_action, compact: true)
+    remote_source: index_path(config.abstract_model.to_param, source_object_id: form.object.id, source_abstract_model: source_abstract_model.to_param, associated_collection: field.name, current_action: current_action, compact: true),
+    dependent_field_selector: dependent_field_selector
   }
 
 - selected_id = (hdv = field.form_default_value).nil? ? selected_id : hdv

--- a/lib/rails_admin/config/fields/types/belongs_to_association.rb
+++ b/lib/rails_admin/config/fields/types/belongs_to_association.rb
@@ -31,6 +31,10 @@ module RailsAdmin
             true
           end
 
+          register_instance_option :dependent_field do
+            false
+          end
+
           def selected_id
             bindings[:object].send(foreign_key)
           end


### PR DESCRIPTION
Dependent field for belongs_to association.

Example:

We have user with country/city.
User chooses country "Russia" and city field now contains all russian cities.
When user changes country  to "France", city field will lost value and select list now contain all "France" cities.
~~~
class User < ActiveRecord::Base
	belongs_to :country
	belongs_to :city

	rails_admin do
		edit do
		  field :city do
		    dependent_field :country
		    associated_collection_scope do
		      country_id = bindings[:controller].params[:dependent_field_value]
		      Proc.new { |scope|
		        scope = scope.where(country_id: country_id) if country_id
		      }
		    end
		  end
		end
  end
end
~~~