### PR TITLE
fix parsing datetime for locales

### DIFF
--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -24,16 +24,16 @@ module RailsAdmin
                   case match
                   when '%A'
                     english = I18n.t('date.day_names', locale: :en)
-                    day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+                    day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/, english[i]) }
                   when '%a'
                     english = I18n.t('date.abbr_day_names', locale: :en)
-                    abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+                    abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/, english[i]) }
                   when '%B'
                     english = I18n.t('date.month_names', locale: :en)[1..-1]
-                    month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+                    month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/, english[i]) }
                   when '%b'
                     english = I18n.t('date.abbr_month_names', locale: :en)[1..-1]
-                    abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+                    abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/, english[i]) }
                   when '%p'
                     date_string = date_string.gsub(/#{I18n.t('date.time.am', default: "am")}/, 'am')
                     date_string = date_string.gsub(/#{I18n.t('date.time.pm', default: "pm")}/, 'pm')


### PR DESCRIPTION
fix datetime to normalize correctly even when one month name (or weekday
name) is substring of another.

It is at least in Czech:
* June (červen) is a substring of Juny (červenec)


I did not create a tests. It should be done like:

    it 'is able to read %B %d, %Y %H:%M for cs locate' do
      # in Czech June (červen) is a substring of Juny (červenec)
      @time = ::Time.new(2014,7,21,23,45).getutc
      I18n.with_locale(:cs) do
        puts I18n.l @time
        @object = FactoryGirl.create(:field_test)
        @object.datetime_field = @field.parse_input(datetime_field: @time.strftime('%B %d, %Y %H:%M'))
        expect(@object.datetime_field.strftime('%Y-%m-%d %H:%M')).to eq(@time.strftime('%Y-%m-%d %H:%M'))
      end 
    end 

But it is not good idea to include Czech locale to the project. What is the best way to test it?

