### PR TITLE
fix ajax uploads with remotipart

### DIFF
--- a/app/assets/javascripts/rails_admin/jquery.remotipart.fixed.js
+++ b/app/assets/javascripts/rails_admin/jquery.remotipart.fixed.js
@@ -1,8 +1,4 @@
-//= require jquery.iframe-transport.js
 //= require_self
-
-
-// This file is frozen in RailsAdmin to cope with https://github.com/JangoSteve/remotipart/pull/50
 
 (function($) {
 
@@ -20,14 +16,13 @@
           // delete settings.beforeSend;
           delete settings.beforeSend;
 
-          settings.iframe      = true;
-          settings.files       = $($.rails.fileInputSelector, form);
-          settings.data        = form.serializeArray();
+          settings.data        = new FormData( this );
+          settings.type        = 'POST';
+          settings.contentType = false;
           settings.processData = false;
 
           // Modify some settings to integrate JS request with rails helpers and middleware
           if (settings.dataType === undefined) { settings.dataType = 'script *'; }
-          settings.data.push({name: 'remotipart_submitted', value: true});
 
           // Allow remotipartSubmit to be cancelled if needed
           if ($.rails.fire(form, 'ajax:remotipartSubmit', [xhr, settings])) {


### PR DESCRIPTION
Problem with Paperclip/Carrierwave upload & ajax 

Hey folks,

I have some issues with uploading images to related model through ajax in modal window.

And rails receive request like that:
```ruby
Started POST "/admin/brand/new" for 127.0.0.1 at 2014-06-23 15:14:44 -0700 (pid:10944)
RailsDevTweaks: Skipping ActionDispatch::Reloader hooks for this request. (pid:10944)
Processing by RailsAdmin::MainController#new as JS (pid:10944)
Parameters: {"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>{","=>{"object Object"=>nil}}}}}}}}}}}}}}}}, "model_name"=>"brand"} (pid:10944)
```

I used formData
https://developer.mozilla.org/en-US/docs/Web/Guide/Using_FormData_Objects
And it perfectly works for me.

rails_admin "0.4.9"
jquery "1.10.2"

related #592