### PR TITLE
Correctly display enums consisting of arrays in the show page

### DIFF
--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -24,6 +24,8 @@ module RailsAdmin
               enum.reject { |_k, v| v.to_s != value.to_s }.keys.first.to_s.presence || value.presence || ' - '
             elsif enum.is_a?(::Array) && enum.first.is_a?(::Array)
               enum.detect { |e|e[1].to_s == value.to_s }.try(:first).to_s.presence || value.presence || ' - '
+            elsif enum.is_a?(::Array) && value.is_a?(::Integer)
+              enum[value] || value.presence || ' - '
             else
               value.presence || ' - '
             end


### PR DESCRIPTION
The show page displays correctly enums when they are hashes or arrays of arrays, but it incorrectly displays enums consisting simply of arrays, such as:
```ruby
['value', 'other_value']
```

This is the form used in Rails enums. This patch correctly displays such enums.