### PR TITLE
fix datetime picker

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.datetimepicker.js
+++ b/app/assets/javascripts/rails_admin/ra.datetimepicker.js
@@ -47,6 +47,8 @@
         this.datepicker.bind("change", function() { widget._onChange(); });
 
         this.datepicker.datepicker(this.options.datepicker);
+
+        widget._onChange();
       }
     },
 


### PR DESCRIPTION
If I edit a field with type: DateTime everything is stored properly.
If I don't edit a time input - time is set to '00:00', because there is no change event.