### PR TITLE
add option for disabling a list page's title attribute for a given colum...

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -136,7 +136,7 @@
               %td.other.left= link_to "...", @other_left_link, class: 'pjax'
             - properties.map{ |property| property.bind(:object, object) }.each do |property|
               - value = property.pretty_value
-              %td{class: "#{property.css_class} #{property.type_css_class}", title: strip_tags(value.to_s)}= value
+              %td{class: "#{property.css_class} #{property.type_css_class}", :title => property.hide_title_attribute ? "" : strip_tags(value.to_s)}= value
             - if @other_right_link ||= other_right && index_path(params.merge(set: (params[:set].to_i + 1)))
               %td.other.right= link_to "...", @other_right_link, class: 'pjax'
             %td.last.links

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -44,6 +44,10 @@ module RailsAdmin
           nil
         end
 
+        register_instance_option :hide_title_attribute do
+          false
+        end
+
         register_instance_option :sortable do
           !virtual? || children_fields.first || false
         end

--- a/spec/integration/config/list/rails_admin_config_list_spec.rb
+++ b/spec/integration/config/list/rails_admin_config_list_spec.rb
@@ -295,6 +295,21 @@ describe 'RailsAdmin Config DSL List Section', type: :request do
       expect(find('style').native.text).to include("#list td.#{PK_COLUMN}_field")
     end
 
+    it "has the option to disable a column's title attribute" do
+      RailsAdmin.config Fan do
+        list do
+          field :name do
+            hide_title_attribute true
+          end
+          field :created_at
+        end
+      end
+      FactoryGirl.create :fan
+      visit index_path(model_name: 'fan')
+      expect(find("#list td.name_field")[:title]).to eq("")
+      expect(find("#list td.created_at_field")[:title]).to_not eq("")
+    end
+
     it 'has option to customize output formatting' do
       RailsAdmin.config Fan do
         list do


### PR DESCRIPTION
The issue is that when adding custom formatting to a field into a list page, the title attribute can turn pretty unsightly as shown in this screenshot:

![title_attribute](https://cloud.githubusercontent.com/assets/614981/3869531/45f0f34e-2095-11e4-9444-5f6eb98e33b3.png)

So I added a config option on a property called 'hide_title_attribute'.  Setting it to true will result in a blank title attribute. 

If the pull request is accepted I'll update the wiki.
