### PR TITLE
Be able to configure default association limit

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -41,6 +41,9 @@ module RailsAdmin
       # been configured
       attr_accessor :default_items_per_page
 
+      # Default association limit
+      attr_accessor :default_associated_collection_limit
+
       attr_reader :default_search_operator
 
       # Configuration option to specify which method names will be searched for
@@ -261,6 +264,7 @@ module RailsAdmin
         @default_hidden_fields[:edit] = [:id, :_id, :created_at, :created_on, :deleted_at, :updated_at, :updated_on, :deleted_on]
         @default_hidden_fields[:show] = [:id, :_id, :created_at, :created_on, :deleted_at, :updated_at, :updated_on, :deleted_on]
         @default_items_per_page = 20
+        @default_associated_collection_limit = 100
         @default_search_operator = 'default'
         @excluded_models = []
         @included_models = []

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -54,7 +54,7 @@ module RailsAdmin
         # preload entire associated collection (per associated_collection_scope) on load
         # Be sure to set limit in associated_collection_scope if set is large
         register_instance_option :associated_collection_cache_all do
-          @associated_collection_cache_all ||= (associated_model_config.abstract_model.count < 100)
+          @associated_collection_cache_all ||= (associated_model_config.abstract_model.count < associated_model_limit)
         end
 
         # Reader for the association's child model's configuration
@@ -99,6 +99,10 @@ module RailsAdmin
 
         def virtual?
           true
+        end
+
+        def associated_model_limit
+          RailsAdmin.config.default_associated_collection_limit
         end
       end
     end

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -160,6 +160,25 @@ describe RailsAdmin::Config::Fields::Base do
       end
       expect(RailsAdmin.config(Team).edit.fields.detect { |f| f.name == :players }.associated_collection_cache_all).to be_falsey
     end
+
+    context "with custom configuration" do
+      before do
+        RailsAdmin.config.default_associated_collection_limit = 5
+      end
+      it 'defaults to true if associated collection count less than than limit' do
+        @players = 4.times.collect do
+          FactoryGirl.create :player
+        end
+        expect(RailsAdmin.config(Team).edit.fields.detect { |f| f.name == :players }.associated_collection_cache_all).to be_truthy
+      end
+
+      it 'defaults to false if associated collection count >= that limit' do
+        @players = 5.times.collect do
+          FactoryGirl.create :player
+        end
+        expect(RailsAdmin.config(Team).edit.fields.detect { |f| f.name == :players }.associated_collection_cache_all).to be_falsey
+      end
+    end
   end
 
   describe '#searchable_columns' do


### PR DESCRIPTION
Currently, you can configure association collection preloading on a per model basis.  If there's no custom configuration for a model, it will preload if the associated count is under 100.  This PR allows you to change that number on an application level.