### PR TITLE
Support for specific locale on rails_admin panel

### DIFF
--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -18,7 +18,7 @@
               %span.show= link_to capitalize_first_letter(abstract_model.config.label_plural), index_path, class: 'pjax'
             %td
               - if last_used
-                = time_ago_in_words last_used
+                = time_ago_in_words last_used, :locale => RailsAdmin.config.locale
                 = t "admin.misc.ago"
             %td
               - count = @count[abstract_model.pretty_name]

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -66,6 +66,9 @@ module RailsAdmin
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
 
+      # Set locale for RailsAdmin pages
+      attr_accessor :locale
+
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -34,7 +34,7 @@ module RailsAdmin
 
         # use the association name as a key, not the association key anymore!
         register_instance_option :label do
-          (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name association.name
+          (@label ||= {})[I18n.locale] ||= abstract_model.model.human_attribute_name association.name, locale: I18n.locale
         end
 
         # scope for possible associable records

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -120,7 +120,7 @@ module RailsAdmin
 
         # Accessor for field's help text displayed below input field.
         register_instance_option :help do
-          (@help ||= {})[::I18n.locale] ||= generic_field_help
+          (@help ||= {})[I18n.locale] ||= generic_field_help
         end
 
         register_instance_option :html_attributes do
@@ -135,7 +135,7 @@ module RailsAdmin
         #
         # @see RailsAdmin::AbstractModel.properties
         register_instance_option :label do
-          (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name name
+          (@label ||= {})[I18n.locale] ||= abstract_model.model.human_attribute_name name, locale: I18n.locale
         end
 
         register_instance_option :hint do

--- a/lib/rails_admin/config/fields/group.rb
+++ b/lib/rails_admin/config/fields/group.rb
@@ -63,7 +63,7 @@ module RailsAdmin
 
         # Configurable group label which by default is group's name humanized.
         register_instance_option :label do
-          (@label ||= {})[::I18n.locale] ||= (parent.fields.detect { |f|f.name == name }.try(:label) || name.to_s.humanize)
+          (@label ||= {})[I18n.locale] ||= (parent.fields.detect { |f|f.name == name }.try(:label) || name.to_s.humanize)
         end
 
         # Configurable help text

--- a/lib/rails_admin/config/fields/types/bson_object_id.rb
+++ b/lib/rails_admin/config/fields/types/bson_object_id.rb
@@ -9,7 +9,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option :label do
-            label = ((@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name name)
+            label = ((@label ||= {})[I18n.locale] ||= abstract_model.model.human_attribute_name(name, locale: I18n.locale))
             label = 'Id' if label == ''
             label
           end

--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -19,7 +19,7 @@ module RailsAdmin
             attr_reader :format, :i18n_scope, :js_plugin_options
 
             def normalize(date_string, format)
-              unless I18n.locale == 'en'
+              unless I18n.locale.to_s == 'en'
                 format.to_s.scan(/%[AaBbp]/) do |match|
                   case match
                   when '%A'

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -56,11 +56,11 @@ module RailsAdmin
       end
 
       register_instance_option :label do
-        (@label ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human
+        (@label ||= {})[I18n.locale] ||= abstract_model.model.model_name.human(locale: I18n.locale)
       end
 
       register_instance_option :label_plural do
-        (@label_plural ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(count: Float::INFINITY, default: label.pluralize)
+        (@label_plural ||= {})[I18n.locale] ||= abstract_model.model.model_name.human(count: Float::INFINITY, default: label.pluralize, locale: I18n.locale)
       end
 
       def pluralize(count)

--- a/lib/rails_admin/i18n.rb
+++ b/lib/rails_admin/i18n.rb
@@ -1,0 +1,34 @@
+require 'i18n'
+
+module RailsAdmin
+  module I18n
+    include ::I18n
+
+    def locale
+      RailsAdmin.config.locale || ::I18n.locale
+    end
+
+    def translate(key, options = {})
+      ::I18n.translate(key, {locale: locale}.merge(options))
+    end
+    alias_method :t, :translate
+
+    def translate!(key, options = {})
+      translate(key, options.merge(raise: true))
+    end
+    alias_method :t!, :translate!
+
+    def localize(key, options = {})
+      ::I18n.localize(key, {locale: locale}.merge(options))
+    end
+    alias_method :l, :localize
+
+    module_function :t
+    module_function :translate
+    module_function :t!
+    module_function :translate!
+    module_function :l
+    module_function :localize
+    module_function :locale
+  end
+end

--- a/lib/rails_admin/i18n_support.rb
+++ b/lib/rails_admin/i18n_support.rb
@@ -1,7 +1,9 @@
-require 'i18n'
+require 'rails_admin/i18n'
 
 module RailsAdmin
   module I18nSupport
+    include I18n
+
     def abbr_day_names
       I18n.t('date.abbr_day_names', raise: true)
     rescue I18n::ArgumentError


### PR DESCRIPTION
My site does not use the English locale, but I do not want to translate / Admin. 
I made the ability to specify a separate locale for rails_admin. 
Can this code be accepted upstream? I beg to point out my mistakes. And I will fix them