### PR TITLE
Fix for #1338

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -135,7 +135,7 @@ module RailsAdmin
 
     def nested_field_association?(field, nested_in)
       field.inverse_of.presence && nested_in.presence && field.inverse_of == nested_in.name &&
-        (@template.instance_variable_get(:@model_config).abstract_model == field.associated_model_config.abstract_model ||
+        (@template.instance_variable_get(:@model_config).abstract_model == field.abstract_model ||
          field.name == nested_in.inverse_of)
     end
   end


### PR DESCRIPTION
field.associated_model_config returns an array, but abstract_model is in field, this fixes the error