### PR TITLE
change count() to count(:all) for rails 4.1

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -40,7 +40,7 @@ module RailsAdmin
       end
 
       def count(options = {}, scope = nil)
-        all(options.merge(limit: false, page: false), scope).count
+        all(options.merge(limit: false, page: false), scope).count(:all)
       end
 
       def destroy(objects)

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -48,7 +48,7 @@ module RailsAdmin
       end
 
       def count(options = {}, scope = nil)
-        all(options.merge(limit: false, page: false), scope).count
+        all(options.merge(limit: false, page: false), scope).count(:all)
       end
 
       def destroy(objects)


### PR DESCRIPTION
I see rails 4.1 only work using count(:all) https://github.com/rails/rails/issues/13648#issuecomment-39352347

it's error when I use joins and select based on joins ex :

joins(:courier_company).select('waybills.*, courier_companies.name as courier_company_name')