### PR TITLE
Capitalize first letter of page titles and flash messages

### DIFF
--- a/app/views/layouts/rails_admin/pjax.html.haml
+++ b/app/views/layouts/rails_admin/pjax.html.haml
@@ -2,14 +2,14 @@
   $('.nav.nav-pills li.active').removeClass('active');
   $('.nav.nav-pills li[data-model="#{@abstract_model.to_param}"]').addClass('active');
 
-%title= "#{@abstract_model.try(:pretty_name) || @page_name} | #{[_get_plugin_name[0] || 'Rails', _get_plugin_name[1] || 'Admin'].join(' ')}"
+%title= capitalize_first_letter("#{@abstract_model.try(:pretty_name) || @page_name} | #{[_get_plugin_name[0] || 'Rails', _get_plugin_name[1] || 'Admin'].join(' ')}")
 .page-header
-  %h1= @page_name
+  %h1= capitalize_first_letter @page_name
 - flash && flash.each do |key, value|
   - key = 'danger' if key.to_s == 'error'
   .alert{class: "alert-#{key}"}
     %a.close{href: '#', :'data-dismiss' => "alert"} &times;
-    = value
+    = capitalize_first_letter value
 = breadcrumb
 %ul.nav.nav-tabs
   = menu_for((@abstract_model ? (@object.try(:persisted?) ? :member : :collection) : :root), @abstract_model, @object)


### PR DESCRIPTION
Hello!

This is a tiny pull request to display page titles and flash messages using the `capitalize_first_letter` helper.