### PR TITLE
Fix for polymorphic association field selector not working with AR

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -144,7 +144,7 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
           object_select.html('<option value=""></option>')
         else
           $.ajax
-            url: urls[type_select.val()]
+            url: urls[type_select.find('option:selected').text()]
             data:
               compact: true
               all: true

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -64,6 +64,18 @@ module RailsAdmin
         end
       end
 
+      def sti_base_class
+        return unless model.columns.any?{|c| c.name == model.inheritance_column }
+        base_class = model
+        model.ancestors.each do |k|
+          break if k == ::ActiveRecord::Base
+          next unless k.is_a?(Class)
+          next unless k.table_name == table_name
+          base_class = k
+        end
+        base_class
+      end
+
       delegate :primary_key, :table_name, to: :model, prefix: false
 
       def encoding

--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -55,13 +55,13 @@ module RailsAdmin
 
           def polymorphic_type_collection
             associated_model_config.collect do |config|
-              [config.label, config.abstract_model.model.name]
+              [config.label, (config.abstract_model.sti_base_class || config.abstract_model.model).name]
             end
           end
 
           def polymorphic_type_urls
             types = associated_model_config.collect do |config|
-              [config.abstract_model.model.name, config.abstract_model.to_param]
+              [config.label, config.abstract_model.to_param]
             end
             ::Hash[*types.collect { |v| [v[0], bindings[:view].index_path(v[1])] }.flatten]
           end


### PR DESCRIPTION
AR stores and queries the STI base class in polymorphic associations. This commit correctly sets the <polymorphic>_type field to the object's STI base class (not the object's class).

Note: I used the rubygem (0.6.5) version because master (0.6.6) is broken. The cerulean theme has not been updated and gives an error, plus a few other css issues., however you should be able to pull also on top of master
