### PR TITLE
Ensure inline lists uses the right Bootstrap 3 css class

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -269,7 +269,7 @@ body.rails_admin {
     /* icons */
     td.links {
       max-width: none;
-      .inline {
+      .list-inline {
         margin:0px;
         li { display:inline-block; }
       }

--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -27,7 +27,7 @@
                 .progress-bar.animate-width-to{:class => "progress-bar-#{get_indicator(percent)}", :'data-animate-length' => ([1.0, percent].max.to_i * 20), :'data-animate-width-to' => "#{[2.0, percent].max.to_i}%", style: "width:2%"}
                   = @count[abstract_model.pretty_name]
             %td.links
-              %ul.inline= menu_for :collection, abstract_model, nil, true
+              %ul.inline.list-inline= menu_for :collection, abstract_model, nil, true
 - if @auditing_adapter && authorized?(:history)
   #block-tables.block
     .content

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -145,7 +145,7 @@
             - if @other_right_link ||= other_right && index_path(params.merge(set: (params[:set].to_i + 1)))
               %td.other.right= link_to "...", @other_right_link, class: 'pjax'
             %td.last.links
-              %ul.inline= menu_for :member, @abstract_model, object, true
+              %ul.inline.list-inline= menu_for :member, @abstract_model, object, true
     - if @objects.respond_to?(:total_count)
       - total_count = @objects.total_count.to_i
       .row


### PR DESCRIPTION
According to the bootstrap migration readme http://getbootstrap.com/migration/ - the .inline class is deprecated on inline lists in favour of .list-inline.

The upshot of this for rails_admin is that the action icons on the index and dashboard page currently look 'squished' together.

This commit adds the .list-inline class  but also keeps the .inline class around for backwards compatibility. 

I notice that this is a common pattern in rails_admin for moving to Bootstrap 3, as there are several deprecated css classes dotted around the place. At some point these should be removed (moving to Bootstrap 3 *is* a breaking change)

PS: Travis-CI is reporting this as a broken build - but this appears to be GC limits with JRuby that's causing the error - unrelated to this pull request.
