### PR TITLE
The datepicker zindex needs to be higher for modals

### DIFF
--- a/app/assets/stylesheets/rails_admin/ra.calendar-additions.scss
+++ b/app/assets/stylesheets/rails_admin/ra.calendar-additions.scss
@@ -6,7 +6,7 @@
 .ui-datepicker {
   /* fix glitches */
   border-width:0px;
-  z-index: 3!important;
+  z-index: 1051!important;
   table{
     margin:0px;
   }


### PR DESCRIPTION
Currently if you click on a datepicker in a modal it is hidden behind the modal overlay. This commit brings it to the front.