### PR TITLE
Fix sidebar-nav z-index issue when total_columns_width is large.

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -33,6 +33,7 @@ body.rails_admin {
     top: 50px;
     bottom: 0;
     background: #eaf0f1;
+    z-index: 100;
   }
 
   /* fat labels in forms */


### PR DESCRIPTION
With rails_admin + Bootstrap 2, setting the total_columns_width to something arbitrarily large (to show all columns) works fine. The window scrolls to the right, showing a large data table.
However, doing the same thing in the latest rails_admin + Bootstrap 3 causes overlap with the sidebar-nav. See the image below.

Added z-index=100 to the .sidebar-nav class should solve the problem.

![rails_admin-issue](https://cloud.githubusercontent.com/assets/855606/5635885/27358dac-95bb-11e4-8038-1014ae815b83.png)
