### PR TITLE
Make the font-awesome 4 scss !optional

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/font-awesome-4-compability.scss
+++ b/app/assets/stylesheets/rails_admin/base/font-awesome-4-compability.scss
@@ -1,153 +1,153 @@
 [class^="icon-"],
 [class*=" icon-"] {
-  @extend .fa
+  @extend .fa !optional;
 }
 
-.icon-glass              { @extend .fa-glass; }
-.icon-music              { @extend .fa-music; }
-.icon-search             { @extend .fa-search; }
-.icon-envelope           { @extend .fa-envelope; }
-.icon-heart              { @extend .fa-heart; }
-.icon-star               { @extend .fa-star; }
-.icon-star-empty         { @extend .fa-star-o; }
-.icon-user               { @extend .fa-user; }
-.icon-film               { @extend .fa-film; }
-.icon-th-large           { @extend .fa-th-large; }
-.icon-th                 { @extend .fa-th; }
-.icon-th-list            { @extend .fa-th-list; }
-.icon-ok                 { @extend .fa-check; }
-.icon-remove             { @extend .fa-times; }
-.icon-zoom-in            { @extend .fa-search-plus; }
-.icon-zoom-out           { @extend .fa-search-minus; }
-.icon-off                { @extend .fa-power-off; }
-.icon-signal             { @extend .fa-signal; }
-.icon-cog                { @extend .fa-cog; }
-.icon-trash              { @extend .fa-trash-o; }
+.icon-glass              { @extend .fa-glass !optional; }
+.icon-music              { @extend .fa-music !optional; }
+.icon-search             { @extend .fa-search !optional; }
+.icon-envelope           { @extend .fa-envelope !optional; }
+.icon-heart              { @extend .fa-heart !optional; }
+.icon-star               { @extend .fa-star !optional; }
+.icon-star-empty         { @extend .fa-star-o !optional; }
+.icon-user               { @extend .fa-user !optional; }
+.icon-film               { @extend .fa-film !optional; }
+.icon-th-large           { @extend .fa-th-large !optional; }
+.icon-th                 { @extend .fa-th !optional; }
+.icon-th-list            { @extend .fa-th-list !optional; }
+.icon-ok                 { @extend .fa-check !optional; }
+.icon-remove             { @extend .fa-times !optional; }
+.icon-zoom-in            { @extend .fa-search-plus !optional; }
+.icon-zoom-out           { @extend .fa-search-minus !optional; }
+.icon-off                { @extend .fa-power-off !optional; }
+.icon-signal             { @extend .fa-signal !optional; }
+.icon-cog                { @extend .fa-cog !optional; }
+.icon-trash              { @extend .fa-trash-o !optional; }
 
-.icon-home               { @extend .fa-home; }
-.icon-file               { @extend .fa-file; }
-.icon-time               { @extend .fa-clock-o; }
-.icon-road               { @extend .fa-road; }
-.icon-download-alt       { @extend .fa-download; }
-.icon-download           { @extend .fa-download; }
-.icon-upload             { @extend .fa-upload; }
-.icon-inbox              { @extend .fa-inbox; }
-.icon-play-circle        { @extend .fa-play-circle; }
-.icon-repeat             { @extend .fa-repeat; }
-.icon-refresh            { @extend .fa-refresh; }
-.icon-list-alt           { @extend .fa-list-alt; }
-.icon-lock               { @extend .fa-lock; }
-.icon-flag               { @extend .fa-flag; }
-.icon-headphones         { @extend .fa-headphones; }
-.icon-volume-off         { @extend .fa-volume-off; }
-.icon-volume-down        { @extend .fa-volume-down; }
-.icon-volume-up          { @extend .fa-volume-up; }
-.icon-qrcode             { @extend .fa-qrcode; }
-.icon-barcode            { @extend .fa-barcode; }
+.icon-home               { @extend .fa-home !optional; }
+.icon-file               { @extend .fa-file !optional; }
+.icon-time               { @extend .fa-clock-o !optional; }
+.icon-road               { @extend .fa-road !optional; }
+.icon-download-alt       { @extend .fa-download !optional; }
+.icon-download           { @extend .fa-download !optional; }
+.icon-upload             { @extend .fa-upload !optional; }
+.icon-inbox              { @extend .fa-inbox !optional; }
+.icon-play-circle        { @extend .fa-play-circle !optional; }
+.icon-repeat             { @extend .fa-repeat !optional; }
+.icon-refresh            { @extend .fa-refresh !optional; }
+.icon-list-alt           { @extend .fa-list-alt !optional; }
+.icon-lock               { @extend .fa-lock !optional; }
+.icon-flag               { @extend .fa-flag !optional; }
+.icon-headphones         { @extend .fa-headphones !optional; }
+.icon-volume-off         { @extend .fa-volume-off !optional; }
+.icon-volume-down        { @extend .fa-volume-down !optional; }
+.icon-volume-up          { @extend .fa-volume-up !optional; }
+.icon-qrcode             { @extend .fa-qrcode !optional; }
+.icon-barcode            { @extend .fa-barcode !optional; }
 
-.icon-tag                { @extend .fa-tag; }
-.icon-tags               { @extend .fa-tags; }
-.icon-book               { @extend .fa-book; }
-.icon-bookmark           { @extend .fa-bookmark; }
-.icon-print              { @extend .fa-print; }
-.icon-camera             { @extend .fa-camera; }
-.icon-font               { @extend .fa-font; }
-.icon-bold               { @extend .fa-bold; }
-.icon-italic             { @extend .fa-italic; }
-.icon-text-height        { @extend .fa-text-height; }
-.icon-text-width         { @extend .fa-text-width; }
-.icon-align-left         { @extend .fa-align-left; }
-.icon-align-center       { @extend .fa-align-center; }
-.icon-align-right        { @extend .fa-align-right; }
-.icon-align-justify      { @extend .fa-align-justify; }
-.icon-list               { @extend .fa-list; }
-.icon-indent-left        { @extend .fa-indent; }
-.icon-indent-right       { @extend .fa-dedent; }
-.icon-facetime-video     { @extend .fa-video-camera; }
-.icon-picture            { @extend .fa-picture-o; }
+.icon-tag                { @extend .fa-tag !optional; }
+.icon-tags               { @extend .fa-tags !optional; }
+.icon-book               { @extend .fa-book !optional; }
+.icon-bookmark           { @extend .fa-bookmark !optional; }
+.icon-print              { @extend .fa-print !optional; }
+.icon-camera             { @extend .fa-camera !optional; }
+.icon-font               { @extend .fa-font !optional; }
+.icon-bold               { @extend .fa-bold !optional; }
+.icon-italic             { @extend .fa-italic !optional; }
+.icon-text-height        { @extend .fa-text-height !optional; }
+.icon-text-width         { @extend .fa-text-width !optional; }
+.icon-align-left         { @extend .fa-align-left !optional; }
+.icon-align-center       { @extend .fa-align-center !optional; }
+.icon-align-right        { @extend .fa-align-right !optional; }
+.icon-align-justify      { @extend .fa-align-justify !optional; }
+.icon-list               { @extend .fa-list !optional; }
+.icon-indent-left        { @extend .fa-indent !optional; }
+.icon-indent-right       { @extend .fa-dedent !optional; }
+.icon-facetime-video     { @extend .fa-video-camera !optional; }
+.icon-picture            { @extend .fa-picture-o !optional; }
 
-.icon-pencil             { @extend .fa-pencil; }
-.icon-map-marker         { @extend .fa-map-marker; }
-.icon-adjust             { @extend .fa-adjust; }
-.icon-tint               { @extend .fa-tint; }
-.icon-edit               { @extend .fa-edit; }
-.icon-share              { @extend .fa-share-square-o; }
-.icon-check              { @extend .fa-check; }
-.icon-move               { @extend .fa-arrows; }
-.icon-step-backward      { @extend .fa-step-backward; }
-.icon-fast-backward      { @extend .fa-fast-backward; }
-.icon-backward           { @extend .fa-backward; }
-.icon-play               { @extend .fa-play; }
-.icon-pause              { @extend .fa-pause; }
-.icon-stop               { @extend .fa-stop; }
-.icon-forward            { @extend .fa-forward; }
-.icon-fast-forward       { @extend .fa-fast-forward; }
-.icon-step-forward       { @extend .fa-step-forward; }
-.icon-eject              { @extend .fa-eject; }
-.icon-chevron-left       { @extend .fa-chevron-left; }
-.icon-chevron-right      { @extend .fa-chevron-right; }
+.icon-pencil             { @extend .fa-pencil !optional; }
+.icon-map-marker         { @extend .fa-map-marker !optional; }
+.icon-adjust             { @extend .fa-adjust !optional; }
+.icon-tint               { @extend .fa-tint !optional; }
+.icon-edit               { @extend .fa-edit !optional; }
+.icon-share              { @extend .fa-share-square-o !optional; }
+.icon-check              { @extend .fa-check !optional; }
+.icon-move               { @extend .fa-arrows !optional; }
+.icon-step-backward      { @extend .fa-step-backward !optional; }
+.icon-fast-backward      { @extend .fa-fast-backward !optional; }
+.icon-backward           { @extend .fa-backward !optional; }
+.icon-play               { @extend .fa-play !optional; }
+.icon-pause              { @extend .fa-pause !optional; }
+.icon-stop               { @extend .fa-stop !optional; }
+.icon-forward            { @extend .fa-forward !optional; }
+.icon-fast-forward       { @extend .fa-fast-forward !optional; }
+.icon-step-forward       { @extend .fa-step-forward !optional; }
+.icon-eject              { @extend .fa-eject !optional; }
+.icon-chevron-left       { @extend .fa-chevron-left !optional; }
+.icon-chevron-right      { @extend .fa-chevron-right !optional; }
 
-.icon-plus-sign          { @extend .fa-plus-circle; }
-.icon-minus-sign         { @extend .fa-minus-circle; }
-.icon-remove-sign        { @extend .fa-times-circle; }
-.icon-ok-sign            { @extend .fa-check-circle; }
-.icon-question-sign      { @extend .fa-question-circle; }
-.icon-info-sign          { @extend .fa-info-circle; }
-.icon-screenshot         { @extend .fa-crosshairs; }
-.icon-remove-circle      { @extend .fa-times-circle-o; }
-.icon-ok-circle          { @extend .fa-check-circle-o; }
-.icon-ban-circle         { @extend .fa-ban; }
-.icon-arrow-left         { @extend .fa-arrow-left; }
-.icon-arrow-right        { @extend .fa-arrow-right; }
-.icon-arrow-up           { @extend .fa-arrow-up; }
-.icon-arrow-down         { @extend .fa-arrow-down; }
-.icon-share-alt          { @extend .fa-share; }
-.icon-resize-full        { @extend .fa-expand; }
-.icon-resize-small       { @extend .fa-compress; }
-.icon-plus               { @extend .fa-plus; }
-.icon-minus              { @extend .fa-minus; }
-.icon-asterisk           { @extend .fa-asterisk; }
+.icon-plus-sign          { @extend .fa-plus-circle !optional; }
+.icon-minus-sign         { @extend .fa-minus-circle !optional; }
+.icon-remove-sign        { @extend .fa-times-circle !optional; }
+.icon-ok-sign            { @extend .fa-check-circle !optional; }
+.icon-question-sign      { @extend .fa-question-circle !optional; }
+.icon-info-sign          { @extend .fa-info-circle !optional; }
+.icon-screenshot         { @extend .fa-crosshairs !optional; }
+.icon-remove-circle      { @extend .fa-times-circle-o !optional; }
+.icon-ok-circle          { @extend .fa-check-circle-o !optional; }
+.icon-ban-circle         { @extend .fa-ban !optional; }
+.icon-arrow-left         { @extend .fa-arrow-left !optional; }
+.icon-arrow-right        { @extend .fa-arrow-right !optional; }
+.icon-arrow-up           { @extend .fa-arrow-up !optional; }
+.icon-arrow-down         { @extend .fa-arrow-down !optional; }
+.icon-share-alt          { @extend .fa-share !optional; }
+.icon-resize-full        { @extend .fa-expand !optional; }
+.icon-resize-small       { @extend .fa-compress !optional; }
+.icon-plus               { @extend .fa-plus !optional; }
+.icon-minus              { @extend .fa-minus !optional; }
+.icon-asterisk           { @extend .fa-asterisk !optional; }
 
-.icon-exclamation-sign   { @extend .fa-exclamation-circle; }
-.icon-gift               { @extend .fa-gift; }
-.icon-leaf               { @extend .fa-leaf; }
-.icon-fire               { @extend .fa-fire; }
-.icon-eye-open           { @extend .fa-eye; }
-.icon-eye-close          { @extend .fa-eye-slash; }
-.icon-warning-sign       { @extend .fa-warning; }
-.icon-plane              { @extend .fa-plane; }
-.icon-calendar           { @extend .fa-calendar; }
-.icon-random             { @extend .fa-random; }
-.icon-comment            { @extend .fa-comment; }
-.icon-magnet             { @extend .fa-magnet; }
-.icon-chevron-up         { @extend .fa-chevron-up; }
-.icon-chevron-down       { @extend .fa-chevron-down; }
-.icon-retweet            { @extend .fa-retweet; }
-.icon-shopping-cart      { @extend .fa-shopping-cart; }
-.icon-folder-close       { @extend .fa-folder; }
-.icon-folder-open        { @extend .fa-folder-open; }
-.icon-resize-vertical    { @extend .fa-arrows-v; }
-.icon-resize-horizontal  { @extend .fa-arrows-h; }
+.icon-exclamation-sign   { @extend .fa-exclamation-circle !optional; }
+.icon-gift               { @extend .fa-gift !optional; }
+.icon-leaf               { @extend .fa-leaf !optional; }
+.icon-fire               { @extend .fa-fire !optional; }
+.icon-eye-open           { @extend .fa-eye !optional; }
+.icon-eye-close          { @extend .fa-eye-slash !optional; }
+.icon-warning-sign       { @extend .fa-warning !optional; }
+.icon-plane              { @extend .fa-plane !optional; }
+.icon-calendar           { @extend .fa-calendar !optional; }
+.icon-random             { @extend .fa-random !optional; }
+.icon-comment            { @extend .fa-comment !optional; }
+.icon-magnet             { @extend .fa-magnet !optional; }
+.icon-chevron-up         { @extend .fa-chevron-up !optional; }
+.icon-chevron-down       { @extend .fa-chevron-down !optional; }
+.icon-retweet            { @extend .fa-retweet !optional; }
+.icon-shopping-cart      { @extend .fa-shopping-cart !optional; }
+.icon-folder-close       { @extend .fa-folder !optional; }
+.icon-folder-open        { @extend .fa-folder-open !optional; }
+.icon-resize-vertical    { @extend .fa-arrows-v !optional; }
+.icon-resize-horizontal  { @extend .fa-arrows-h !optional; }
 
-.icon-hdd                { @extend .fa-hdd-o; }
-.icon-bullhorn           { @extend .fa-bullhorn; }
-.icon-bell               { @extend .fa-bell; }
-.icon-certificate        { @extend .fa-certificate; }
-.icon-thumbs-up          { @extend .fa-thumbs-up; }
-.icon-thumbs-down        { @extend .fa-thumbs-down; }
-.icon-hand-right         { @extend .fa-hand-o-right; }
-.icon-hand-left          { @extend .fa-hand-o-left; }
-.icon-hand-up            { @extend .fa-hand-o-up; }
-.icon-hand-down          { @extend .fa-hand-o-down; }
-.icon-circle-arrow-right { @extend .fa-arrow-circle-right; }
-.icon-circle-arrow-left  { @extend .fa-arrow-circle-left; }
-.icon-circle-arrow-up    { @extend .fa-arrow-circle-up; }
-.icon-circle-arrow-down  { @extend .fa-arrow-circle-down; }
-.icon-globe              { @extend .fa-globe; }
-.icon-wrench             { @extend .fa-wrench; }
-.icon-tasks              { @extend .fa-tasks; }
-.icon-filter             { @extend .fa-filter; }
-.icon-briefcase          { @extend .fa-briefcase; }
-.icon-fullscreen         { @extend .fa-arrows-alt; }
+.icon-hdd                { @extend .fa-hdd-o !optional; }
+.icon-bullhorn           { @extend .fa-bullhorn !optional; }
+.icon-bell               { @extend .fa-bell !optional; }
+.icon-certificate        { @extend .fa-certificate !optional; }
+.icon-thumbs-up          { @extend .fa-thumbs-up !optional; }
+.icon-thumbs-down        { @extend .fa-thumbs-down !optional; }
+.icon-hand-right         { @extend .fa-hand-o-right !optional; }
+.icon-hand-left          { @extend .fa-hand-o-left !optional; }
+.icon-hand-up            { @extend .fa-hand-o-up !optional; }
+.icon-hand-down          { @extend .fa-hand-o-down !optional; }
+.icon-circle-arrow-right { @extend .fa-arrow-circle-right !optional; }
+.icon-circle-arrow-left  { @extend .fa-arrow-circle-left !optional; }
+.icon-circle-arrow-up    { @extend .fa-arrow-circle-up !optional; }
+.icon-circle-arrow-down  { @extend .fa-arrow-circle-down !optional; }
+.icon-globe              { @extend .fa-globe !optional; }
+.icon-wrench             { @extend .fa-wrench !optional; }
+.icon-tasks              { @extend .fa-tasks !optional; }
+.icon-filter             { @extend .fa-filter !optional; }
+.icon-briefcase          { @extend .fa-briefcase !optional; }
+.icon-fullscreen         { @extend .fa-arrows-alt !optional; }
 
 .icon-white              { color:white; }


### PR DESCRIPTION
This was brought up in #1896 - I'm currently upgrading our app from Rails 3.2 to Rails 4.2 and so have upgraded Sass and rails_admin, and the latest Sass won't compile `font-awesome-4-compability.scss` without the `!optional` argument because it can't find the font-awesome 4 references - we haven't moved to font-awesome 4 (and don't intend to).