### PR TITLE
Change label-important class to label-danger for Bootstrap 3

### DIFF
--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -7,6 +7,6 @@
     - if user_link = edit_user_link
       %li= user_link
     - if logout_path.present?
-      %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-important'), logout_path, method: logout_method
+      %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-danger'), logout_path, method: logout_method
     - if _current_user.respond_to?(:email) && _current_user.email.present?
       %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", style: 'padding-top:5px'

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -142,5 +142,10 @@ describe RailsAdmin, type: :request do
       visit dashboard_path
       is_expected.to have_content 'Log out'
     end
+
+    it 'has label-danger class on log out link' do
+      visit dashboard_path
+      is_expected.to have_selector('.label-danger')
+    end
   end
 end


### PR DESCRIPTION
The 'label-important' class was removed in Bootstrap 3. This patch changes the class on the log out link in rails_admin to use the new 'label-danger' class as documented here: http://getbootstrap.com/components/#labels