### PR TITLE
Fixes a few minor Bootstrap 3 issues

### DIFF
--- a/app/views/rails_admin/main/_submit_buttons.html.haml
+++ b/app/views/rails_admin/main/_submit_buttons.html.haml
@@ -1,16 +1,18 @@
 %input{type: :hidden, name: 'return_to', value: (params[:return_to].presence || request.referer)}
 %br
-.form-actions
-  %button.btn.btn-primary{type: "submit", name: "_save", :'data-disable-with' => t("admin.form.save")}
-    %i.icon-white.icon-ok
-    = t("admin.form.save")
-  %span.extra_buttons
-    - if authorized? :new, @abstract_model
-      %button.btn.btn-info{type: "submit", name: "_add_another", :'data-disable-with' => t("admin.form.save_and_add_another")}
-        = t("admin.form.save_and_add_another")
-    - if authorized? :edit, @abstract_model
-      %button.btn.btn-info{type: "submit", name: "_add_edit", :'data-disable-with' => t("admin.form.save_and_edit")}
-        = t("admin.form.save_and_edit")
-    %button.btn{type: "submit", name: "_continue", :'data-disable-with' => t("admin.form.cancel")}
-      %i.icon-remove
-      = t("admin.form.cancel")
+
+.form-group
+  .col-sm-offset-2.col-sm-10
+    %button.btn.btn-primary{type: "submit", name: "_save", :'data-disable-with' => t("admin.form.save")}
+      %i.icon-white.icon-ok
+      = t("admin.form.save")
+    %span.extra_buttons
+      - if authorized? :new, @abstract_model
+        %button.btn.btn-info{type: "submit", name: "_add_another", :'data-disable-with' => t("admin.form.save_and_add_another")}
+          = t("admin.form.save_and_add_another")
+      - if authorized? :edit, @abstract_model
+        %button.btn.btn-info{type: "submit", name: "_add_edit", :'data-disable-with' => t("admin.form.save_and_edit")}
+          = t("admin.form.save_and_edit")
+      %button.btn{type: "submit", name: "_continue", :'data-disable-with' => t("admin.form.cancel")}
+        %i.icon-remove
+        = t("admin.form.cancel")

--- a/app/views/rails_admin/main/history.html.haml
+++ b/app/views/rails_admin/main/history.html.haml
@@ -7,10 +7,12 @@
 
 = form_tag("", method: "get", class: "search pjax-form form-inline") do
   .well
-    %input{name: "query", type: "search", value: query, placeholder: "#{t("admin.misc.filter")}", class: 'input-small'}
-    %button.btn.btn-primary{type: "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("admin.misc.refresh")}
-      %i.icon-white.icon-refresh
-      = t("admin.misc.refresh")
+    .input-group
+      %input.form-control.input-small{name: "query", type: "search", value: query, placeholder: "#{t("admin.misc.filter")}", class: 'input-small'}
+      %span.input-group-btn
+        %button.btn.btn-primary{type: "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("admin.misc.refresh")}
+          %i.icon-white.icon-refresh
+          = t("admin.misc.refresh")
 %table#history.table.table-striped.table-condensed
   %thead
     %tr


### PR DESCRIPTION
Since the recent update from bootstrap 2 to 3, there have been a few minor layout niggles that have been overlooked. This pull request fixes:

- The history index page filter input box group
- The "form-actions" section on the add/edit forms

I'll fix the rest of the issues as and when I find them. For example, the datetime picker field is next on my list to fix (input corners not rounded).

Hope this helps tidy things up a little bit!

Rikki