### PR TITLE
Adds POST as a verb for the delete action

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -77,7 +77,7 @@ module RailsAdmin
     end
 
     def redirect_to_on_success
-      notice = t('admin.flash.successful', name: @model_config.label, action: t("admin.actions.#{@action.key}.done"))
+      notice = I18n.t('admin.flash.successful', name: @model_config.label, action: I18n.t("admin.actions.#{@action.key}.done"))
       if params[:_add_another]
         redirect_to new_path(return_to: params[:return_to]), flash: {success: notice}
       elsif params[:_add_edit]
@@ -103,7 +103,7 @@ module RailsAdmin
     end
 
     def handle_save_error(whereto = :new)
-      flash.now[:error] = t('admin.flash.error', name: @model_config.label, action: t("admin.actions.#{@action.key}.done").html_safe).html_safe
+      flash.now[:error] = I18n.t('admin.flash.error', name: @model_config.label, action: I18n.t("admin.actions.#{@action.key}.done").html_safe).html_safe
       flash.now[:error] += %(<br>- #{@object.errors.full_messages.join('<br>- ')}).html_safe
 
       respond_to do |format|
@@ -114,7 +114,7 @@ module RailsAdmin
 
     def check_for_cancel
       return unless params[:_continue] || (params[:bulk_action] && !params[:bulk_ids])
-      redirect_to(back_or_index, flash: {info: t('admin.flash.noaction')})
+      redirect_to(back_or_index, flash: {info: I18n.t('admin.flash.noaction')})
     end
 
     def get_collection(model_config, scope, pagination)

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -32,8 +32,8 @@ module RailsAdmin
                 @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
               end
 
-              flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
-              flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
+              flash[:success] = I18n.t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: I18n.t('admin.actions.delete.done')) unless destroyed.empty?
+              flash[:error] = I18n.t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: I18n.t('admin.actions.delete.done')) unless not_destroyed.empty?
 
               redirect_to back_or_index
 

--- a/lib/rails_admin/config/actions/delete.rb
+++ b/lib/rails_admin/config/actions/delete.rb
@@ -34,10 +34,10 @@ module RailsAdmin
               redirect_path = nil
               @auditing_adapter && @auditing_adapter.delete_object(@object, @abstract_model, _current_user)
               if @object.destroy
-                flash[:success] = t('admin.flash.successful', name: @model_config.label, action: t('admin.actions.delete.done'))
+                flash[:success] = I18n.t('admin.flash.successful', name: @model_config.label, action: I18n.t('admin.actions.delete.done'))
                 redirect_path = index_path
               else
-                flash[:error] = t('admin.flash.error', name: @model_config.label, action: t('admin.actions.delete.done'))
+                flash[:error] = I18n.t('admin.flash.error', name: @model_config.label, action: I18n.t('admin.actions.delete.done'))
                 redirect_path = back_or_index
               end
 


### PR DESCRIPTION
I was trying to delete a resource and received an error saying: `No route matches [POST] /author/1/delete`

The error was happening because the DELETE route for rails admin is expected to use either GET (to access the delete view) or DELETE (for the destroy action). But the form was generated to have its method attribute equal to POST. AFAICT, this is normal behavior and the real http verb is kept in a hidden field with name `_method`. See actionview-4.1.7/lib/action_view/helpers/form_tag_helper.rb @ line 714 ActionView::Helpers::FormTagHelper#extra_tags_for_form.

In any case, I made the changes in this PR and it is now working for me (although the flash message is not showing). Also I had to prefix `t` with `I18n`.

Am I missing something? Can anyone else delete resources? When you do, does the form submit a POST or a DELETE request?

I had similar problems with the edit action (also fixed by this PR).