### PR TITLE
try to grab the current_user id first for paper trail

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -58,7 +58,9 @@ module RailsAdmin
       instance_eval(&RailsAdmin::Config.audit_with)
     end
 
-    alias_method :user_for_paper_trail, :_current_user
+    def user_for_paper_trail
+      _current_user.try(:id) || _current_user
+    end
 
     rescue_from RailsAdmin::ObjectNotFound do
       flash[:error] = I18n.t('admin.flash.object_not_found', model: @model_name, id: params[:id])


### PR DESCRIPTION
With the current version of rails_admin and paper_trail 4.0.0.beta (not sure about earlier versions), the `whodunnit` field for updated versions just stores a ruby object reference -- something like `#<User:0x007f3434b429a8>` -- instead of an actual ActiveRecord id.

This change fixes the problem by explicitly attempting to pull an id out of the `current_user` first, and falling back to the default serialization if that doesn't work. It mirrors the paper_trail recommended technique discussed at https://github.com/airblade/paper_trail/issues/316.