### PR TITLE
fix: nested forms are not indented properly since upgrade to Bootstrap3

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -117,8 +117,6 @@ body.rails_admin {
       fieldset {
         margin-left:-10px;
         .control-group > label {
-          padding-left:10px;
-          width:135px;
         }
         legend {
           float:left;
@@ -134,8 +132,6 @@ body.rails_admin {
       fieldset {
         margin-left:-20px;
         .control-group > label {
-          padding-left:20px;
-          width:125px;
         }
         legend {
           margin-left:20px;

--- a/app/views/rails_admin/main/_form_nested_many.html.haml
+++ b/app/views/rails_admin/main/_form_nested_many.html.haml
@@ -1,4 +1,4 @@
-.controls{data: { nestedmany: true }}
+.controls.col-md-offset-2{data: { nestedmany: true }}
   .btn-group
     %a.btn.btn-info.toggler{:'data-toggle' => "button", :'data-target' => "#{form.jquery_namespace(field)} > .tab-content, #{form.jquery_namespace(field)} > .controls > .nav", class: (field.active? ? 'active' : '')}
       %i.icon-white


### PR DESCRIPTION
fixes #2205 

_form_nested_many was msising Bootstrap3 class .col-md-offset-2 to be aligend to preceeding btn-group.

theming.css contained four rules that are not necessary thanks to the change in the partial.

