### PR TITLE
Fix dashboard history authorized check

### DIFF
--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -28,7 +28,7 @@
                   = @count[abstract_model.pretty_name]
             %td.links
               %ul.inline.list-inline= menu_for :collection, abstract_model, nil, true
-- if @auditing_adapter && authorized?(:history)
+- if @auditing_adapter && authorized?(:history_index)
   #block-tables.block
     .content
       %h2= t("admin.actions.history_index.menu")


### PR DESCRIPTION
When using CanCan (or CanCanCan) the ```can :history, :all``` ability doesn't show the history index on the dashboard. This minor PR fixes this issue by checking that the ```:history_index``` action rather than ```:history``` in app/views/rails_admin/main/dashboard.html.haml.