### PR TITLE
Fix Postgres column names

### DIFF
--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -27,7 +27,7 @@ module RailsAdmin
                 @max = current_count > @max ? current_count : @max
                 @count[t.pretty_name] = current_count
                 next unless t.properties.detect { |c| c.name == :updated_at }
-                @most_recent_changes[t.pretty_name] = t.first(sort: "#{t.table_name}.updated_at").try(:updated_at)
+                @most_recent_changes[t.pretty_name] = t.first(sort: :updated_at).try(:updated_at)
               end
             end
             render @action.template_name, status: (flash[:error].present? ? :not_found : 200)

--- a/lib/rails_admin/version.rb
+++ b/lib/rails_admin/version.rb
@@ -2,7 +2,7 @@ module RailsAdmin
   class Version
     MAJOR = 0
     MINOR = 6
-    PATCH = 7
+    PATCH = 8
     PRE = nil
 
     class << self


### PR DESCRIPTION
Rails Admin sometimes fails because column names are not quoted.