### PR TITLE
Add respond to email. Fixes #2221

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -32,6 +32,7 @@ module RailsAdmin
     end
 
     def edit_user_link
+      return nil unless _current_user.respond_to?(:email)
       return nil unless abstract_model = RailsAdmin.config(_current_user.class).abstract_model
       return nil unless (edit_action = RailsAdmin::Config::Actions.find(:edit, controller: controller, abstract_model: abstract_model, object: _current_user)).try(:authorized?)
       link_to _current_user.email, url_for(action: edit_action.action_name, model_name: abstract_model.to_param, id: _current_user.id, controller: 'rails_admin/main')

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -363,5 +363,19 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
         expect(helper.bulk_menu(RailsAdmin::AbstractModel.new(Player))).not_to match('blub')
       end
     end
+
+    describe '#edit_user_link' do
+      it "don't include email column" do
+        allow(helper).to receive(:_current_user).and_return(FactoryGirl.create(:player))
+        result = helper.edit_user_link
+        expect(result).to eq nil
+      end
+
+      it 'include email column' do
+        allow(helper).to receive(:_current_user).and_return(FactoryGirl.create(:user))
+        result = helper.edit_user_link
+        expect(result).to match('href')
+      end
+    end
   end
 end


### PR DESCRIPTION
There was a change in the navigation bar part from [v0.6.7](https://github.com/sferik/rails_admin/commit/10655cbfe972a2972b6580175f8be7fe2e20572c#diff-8c1c18ad5136ae11f98c589618f07fc5L35).
This change generate the #2221 problem.

Therefore, I added of the confirmation whether user model has the email column.