### PR TITLE
Fix incorrect counts for capsuled models with the same name

### DIFF
--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -12,7 +12,7 @@
           - index_path = index_path(model_name: abstract_model.to_param)
           - row_class = "#{cycle("odd", "even")}#{" link" if index_path} #{abstract_model.param_key}_links"
           %tr{class: row_class, :"data-link" => index_path}
-            - last_used = @most_recent_changes[abstract_model.pretty_name]
+            - last_used = @most_recent_changes[abstract_model.model.name]
             - active = last_used.try(:today?)
             %td
               %span.show= link_to capitalize_first_letter(abstract_model.config.label_plural), index_path, class: 'pjax'
@@ -21,11 +21,11 @@
                 = time_ago_in_words last_used
                 = t "admin.misc.ago"
             %td
-              - count = @count[abstract_model.pretty_name]
+              - count = @count[abstract_model.model.name]
               - percent = count > 0 ? (@max <= 1 ? count : ((Math.log(count+1) * 100.0) / Math.log(@max+1)).to_i) : -1
               .progress{style: "margin-bottom:0px", class: "progress-#{get_indicator(percent)} #{active && 'active progress-striped'}"  }
                 .progress-bar.animate-width-to{:class => "progress-bar-#{get_indicator(percent)}", :'data-animate-length' => ([1.0, percent].max.to_i * 20), :'data-animate-width-to' => "#{[2.0, percent].max.to_i}%", style: "width:2%"}
-                  = @count[abstract_model.pretty_name]
+                  = @count[abstract_model.model.name]
             %td.links
               %ul.inline.list-inline= menu_for :collection, abstract_model, nil, true
 - if @auditing_adapter && authorized?(:history_index)

--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -25,9 +25,9 @@ module RailsAdmin
                 scope = @authorization_adapter && @authorization_adapter.query(:index, t)
                 current_count = t.count({}, scope)
                 @max = current_count > @max ? current_count : @max
-                @count[t.pretty_name] = current_count
+                @count[t.model.name] = current_count
                 next unless t.properties.detect { |c| c.name == :updated_at }
-                @most_recent_changes[t.pretty_name] = t.first(sort: "#{t.table_name}.updated_at").try(:updated_at)
+                @most_recent_changes[t.model.name] = t.first(sort: "#{t.table_name}.updated_at").try(:updated_at)
               end
             end
             render @action.template_name, status: (flash[:error].present? ? :not_found : 200)

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -25,6 +25,26 @@ describe RailsAdmin::MainController, type: :controller do
       expect(RailsAdmin.config(Player).abstract_model).not_to receive(:count)
       controller.dashboard
     end
+
+    it "counts are different for same-named models in different modules" do
+      allow(RailsAdmin.config(User::Confirmed).abstract_model).to receive(:count).and_return(10)
+      allow(RailsAdmin.config(Comment::Confirmed).abstract_model).to receive(:count).and_return(0)
+
+      controller.dashboard
+      expect(controller.instance_variable_get("@count")["User::Confirmed"]).to be 10
+      expect(controller.instance_variable_get("@count")["Comment::Confirmed"]).to be 0
+    end
+
+    it "most recent change dates are different for same-named models in different modules" do
+      user_update = 10.days.ago.to_date
+      comment_update = 20.days.ago.to_date
+      FactoryGirl.create(:user_confirmed, :updated_at => user_update)
+      FactoryGirl.create(:comment_confirmed, :updated_at => comment_update)
+
+      controller.dashboard
+      expect(controller.instance_variable_get("@most_recent_changes")["User::Confirmed"]).to eq user_update
+      expect(controller.instance_variable_get("@most_recent_changes")["Comment::Confirmed"]).to eq comment_update
+    end
   end
 
   describe '#check_for_cancel' do

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -26,24 +26,24 @@ describe RailsAdmin::MainController, type: :controller do
       controller.dashboard
     end
 
-    it "counts are different for same-named models in different modules" do
+    it 'counts are different for same-named models in different modules' do
       allow(RailsAdmin.config(User::Confirmed).abstract_model).to receive(:count).and_return(10)
       allow(RailsAdmin.config(Comment::Confirmed).abstract_model).to receive(:count).and_return(0)
 
       controller.dashboard
-      expect(controller.instance_variable_get("@count")["User::Confirmed"]).to be 10
-      expect(controller.instance_variable_get("@count")["Comment::Confirmed"]).to be 0
+      expect(controller.instance_variable_get('@count')['User::Confirmed']).to be 10
+      expect(controller.instance_variable_get('@count')['Comment::Confirmed']).to be 0
     end
 
-    it "most recent change dates are different for same-named models in different modules" do
+    it 'most recent change dates are different for same-named models in different modules' do
       user_update = 10.days.ago.to_date
       comment_update = 20.days.ago.to_date
-      FactoryGirl.create(:user_confirmed, :updated_at => user_update)
-      FactoryGirl.create(:comment_confirmed, :updated_at => comment_update)
+      FactoryGirl.create(:user_confirmed, updated_at: user_update)
+      FactoryGirl.create(:comment_confirmed, updated_at: comment_update)
 
       controller.dashboard
-      expect(controller.instance_variable_get("@most_recent_changes")["User::Confirmed"]).to eq user_update
-      expect(controller.instance_variable_get("@most_recent_changes")["Comment::Confirmed"]).to eq comment_update
+      expect(controller.instance_variable_get('@most_recent_changes')['User::Confirmed']).to eq user_update
+      expect(controller.instance_variable_get('@most_recent_changes')['Comment::Confirmed']).to eq comment_update
     end
   end
 

--- a/spec/dummy_app/app/active_record/user/confirmed.rb
+++ b/spec/dummy_app/app/active_record/user/confirmed.rb
@@ -1,0 +1,4 @@
+class User
+  class Confirmed < User
+  end
+end

--- a/spec/dummy_app/app/mongoid/user/confirmed.rb
+++ b/spec/dummy_app/app/mongoid/user/confirmed.rb
@@ -1,0 +1,4 @@
+class User
+  class Confirmed < User
+  end
+end

--- a/spec/dummy_app/db/migrate/20150421143020_add_type_to_users.rb
+++ b/spec/dummy_app/db/migrate/20150421143020_add_type_to_users.rb
@@ -1,0 +1,6 @@
+class AddTypeToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :type, :string
+  end
+
+end

--- a/spec/dummy_app/db/migrate/20150421143020_add_type_to_users.rb
+++ b/spec/dummy_app/db/migrate/20150421143020_add_type_to_users.rb
@@ -1,6 +1,0 @@
-class AddTypeToUsers < ActiveRecord::Migration
-  def change
-    add_column :users, :type, :string
-  end
-
-end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,7 +44,7 @@ FactoryGirl.define do
     sequence(:email) { |n| "username_#{n}@example.com" }
     sequence(:password) { |_n| 'password' }
 
-    factory :user_confirmed, :class => User::Confirmed
+    factory :user_confirmed, class: User::Confirmed
   end
 
   factory :field_test do
@@ -62,7 +62,7 @@ FactoryGirl.define do
       EOF
     end
 
-    factory :comment_confirmed, :class => Comment::Confirmed do
+    factory :comment_confirmed, class: Comment::Confirmed do
       content('something')
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,6 +43,8 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "username_#{n}@example.com" }
     sequence(:password) { |_n| 'password' }
+
+    factory :user_confirmed, :class => User::Confirmed
   end
 
   factory :field_test do
@@ -58,6 +60,10 @@ FactoryGirl.define do
         cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
         proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
       EOF
+    end
+
+    factory :comment_confirmed, :class => Comment::Confirmed do
+      content('something')
     end
   end
 


### PR DESCRIPTION
If I have 2 models that share the same name but are encapsulated in different modules the entity counts on the dashboard page are incorrect. This happens as the counts are stored in a hash using the value `AbstractModel#pretty_name` as key. This method itself uses `Model#model_name` which strips the module name. In this specific case this results in the same key for different models and therefore in wrong counts. 

This can be fixed by using `Model#name` instead of `Model#model_name` for the key.