### PR TITLE
Avoid to delete all with deleted resource ids

### DIFF
--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -15,10 +15,14 @@ module RailsAdmin
         register_instance_option :controller do
           proc do
             if request.post? # BULK DELETE
-
               @objects = list_entries(@model_config, :destroy)
 
-              render @action.template_name
+              if @objects.blank?
+                flash[:error] = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
+                redirect_to index_path
+              else
+                render @action.template_name
+              end
 
             elsif request.delete? # BULK DESTROY
 

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -25,22 +25,25 @@ module RailsAdmin
               end
 
             elsif request.delete? # BULK DESTROY
-
               @objects = list_entries(@model_config, :destroy)
-              processed_objects = @abstract_model.destroy(@objects)
+              if @objects.blank?
+                msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
+                render text: msg, status: :not_found
+              else
+                processed_objects = @abstract_model.destroy(@objects)
 
-              destroyed = processed_objects.select(&:destroyed?)
-              not_destroyed = processed_objects - destroyed
+                destroyed = processed_objects.select(&:destroyed?)
+                not_destroyed = processed_objects - destroyed
 
-              destroyed.each do |object|
-                @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
+                destroyed.each do |object|
+                  @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
+                end
+
+                flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
+                flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
+
+                redirect_to back_or_index
               end
-
-              flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
-              flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
-
-              redirect_to back_or_index
-
             end
           end
         end

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -25,24 +25,30 @@ module RailsAdmin
               end
 
             elsif request.delete? # BULK DESTROY
-              @objects = list_entries(@model_config, :destroy)
-              if @objects.blank?
+
+              if params[:bulk_ids].blank?
                 msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
                 render text: msg, status: :not_found
               else
-                processed_objects = @abstract_model.destroy(@objects)
+                @objects = list_entries(@model_config, :destroy)
+                if @objects.blank?
+                  msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
+                  render text: msg, status: :not_found
+                else
+                  processed_objects = @abstract_model.destroy(@objects)
 
-                destroyed = processed_objects.select(&:destroyed?)
-                not_destroyed = processed_objects - destroyed
+                  destroyed = processed_objects.select(&:destroyed?)
+                  not_destroyed = processed_objects - destroyed
 
-                destroyed.each do |object|
-                  @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
+                  destroyed.each do |object|
+                    @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
+                  end
+
+                  flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
+                  flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
+
+                  redirect_to back_or_index
                 end
-
-                flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
-                flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
-
-                redirect_to back_or_index
               end
             end
           end

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -26,30 +26,30 @@ module RailsAdmin
 
             elsif request.delete? # BULK DESTROY
 
-              if params[:bulk_ids].blank?
-                msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
-                render text: msg, status: :not_found
-              else
-                @objects = list_entries(@model_config, :destroy)
-                if @objects.blank?
-                  msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
-                  render text: msg, status: :not_found
-                else
-                  processed_objects = @abstract_model.destroy(@objects)
+              destroyed = nil
+              not_destroyed = nil
 
+              unless params[:bulk_ids].blank?
+                @objects = list_entries(@model_config, :destroy)
+                unless @objects.blank?
+                  processed_objects = @abstract_model.destroy(@objects)
                   destroyed = processed_objects.select(&:destroyed?)
                   not_destroyed = processed_objects - destroyed
-
                   destroyed.each do |object|
                     @auditing_adapter && @auditing_adapter.delete_object(object, @abstract_model, _current_user)
                   end
-
-                  flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
-                  flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
-
-                  redirect_to back_or_index
                 end
               end
+
+              if destroyed.nil?
+                msg = t('admin.flash.error', name: pluralize(0, @model_config.label), action: t('admin.actions.delete.done'))
+                render text: msg, status: :not_found
+              else
+                flash[:success] = t('admin.flash.successful', name: pluralize(destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless destroyed.empty?
+                flash[:error] = t('admin.flash.error', name: pluralize(not_destroyed.count, @model_config.label), action: t('admin.actions.delete.done')) unless not_destroyed.empty?
+                redirect_to back_or_index
+              end
+
             end
           end
         end

--- a/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
+++ b/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
@@ -38,6 +38,13 @@ describe 'RailsAdmin Basic Bulk Action', type: :request do
       expect(response.response_code).to eq 404
       expect(response.body).to match /0 players failed to be deleted/i
     end
+
+    it 'returns 404 error for DELETE request without bulk_ids' do
+      expect(Player.count).to eq @players.length
+      delete(bulk_delete_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: ""))
+      expect(response.response_code).to eq 404
+      expect(response.body).to match /0 players failed to be deleted/i
+    end
   end
 
   describe 'bulk_export' do

--- a/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
+++ b/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
@@ -28,6 +28,16 @@ describe 'RailsAdmin Basic Bulk Action', type: :request do
       is_expected.to have_no_content(@players.first.name)
       is_expected.to have_content(@players.last.name)
     end
+
+    it 'returns 404 error for DELETE request if the records are already deleted' do
+      expect(Player.count).to eq @players.length
+      player_ids = [@players.first.id]
+      @players.first.destroy # delete selected object before send request to delete it.
+
+      delete(bulk_delete_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: player_ids))
+      expect(response.response_code).to eq 404
+      expect(response.body).to match /0 players failed to be deleted/i
+    end
   end
 
   describe 'bulk_export' do

--- a/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
+++ b/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
@@ -12,6 +12,22 @@ describe 'RailsAdmin Basic Bulk Action', type: :request do
       post(bulk_action_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: @players.collect(&:id)))
       @players.each { |player| expect(response.body).to include(player.name) }
     end
+
+    it 'redirects to list when all of the records is already deleted' do
+      expect(Player.count).to eq @players.length
+      player_ids = [@players.first.id]
+      @players.first.destroy # delete selected object before send request to show bulk_delete confirmation.
+
+      post(bulk_action_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: player_ids))
+      expect(response.response_code).to eq 302
+
+      index_url = response.headers['Location']
+      expect(URI.parse(index_url).path).to eq(index_path(model_name: 'player'))
+      visit index_url
+
+      is_expected.to have_no_content(@players.first.name)
+      is_expected.to have_content(@players.last.name)
+    end
   end
 
   describe 'bulk_export' do

--- a/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
+++ b/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
@@ -36,14 +36,14 @@ describe 'RailsAdmin Basic Bulk Action', type: :request do
 
       delete(bulk_delete_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: player_ids))
       expect(response.response_code).to eq 404
-      expect(response.body).to match /0 players failed to be deleted/i
+      expect(response.body).to match(/0 players failed to be deleted/i)
     end
 
     it 'returns 404 error for DELETE request without bulk_ids' do
       expect(Player.count).to eq @players.length
-      delete(bulk_delete_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: ""))
+      delete(bulk_delete_path(bulk_action: 'bulk_delete', model_name: 'player', bulk_ids: ''))
       expect(response.response_code).to eq 404
-      expect(response.body).to match /0 players failed to be deleted/i
+      expect(response.body).to match(/0 players failed to be deleted/i)
     end
   end
 


### PR DESCRIPTION
In the following cases, bulk_delete action deletes all records. This pull request fixes them.

## A. When delete the selected records before show confirmation

1. UserA visits list page
2. UserA selects records
3. UserB deletes the records which are selected by UserA
4. UserA clicks "Delete selected Functions Workers"
5. rails_admin renders confirmation form without buld_ids parameter
6. UserA clicks "Yes, I'm sure"
7. rails_admin deletes the resource without bulk_ids
    - All of the record in the table are deleted

## B. When delete the selected records before send DELETE request

1. UserA visits list page
2. UserA selects records
3. UserA clicks "Delete selected Functions Workers"
4. UserB deletes the records which are selected by UserA
5. UserA clicks "Yes, I'm sure"
6. rails_admin deletes the resource without bulk_ids
    - All of the record in the table are deleted

## C. When send DELETE request without bulk_ids

1. UserA sends the request without bulk_ids
    - by attacker
    - a mistake not from browser but using some HTTP client
2. rails_admin deletes the resource without bulk_ids
    - All of the record in the table are deleted

