### PR TITLE
Accept MySQL's 'utf8mb4' as a kind of UTF-8 for CSV export

### DIFF
--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -3,7 +3,7 @@ require 'csv'
 
 module RailsAdmin
   class CSVConverter
-    UTF8_ENCODINGS = [nil, '', 'utf8', 'utf-8', 'unicode', 'UTF8', 'UTF-8', 'UNICODE']
+    UTF8_ENCODINGS = [nil, '', 'utf8', 'utf-8', 'unicode', 'UTF8', 'UTF-8', 'UNICODE', 'utf8mb4']
     TARGET_ENCODINGS = %w(UTF-8 UTF-16LE UTF-16BE UTF-32LE UTF-32BE UTF-7 ISO-8859-1 ISO-8859-15 IBM850 MacRoman Windows-1252 ISO-8859-3 IBM852 ISO-8859-2 Windows-1250 IBM855 ISO-8859-5 KOI8-R MacCyrillic Windows-1251 IBM866 GB2312 GBK GB18030 Big5 Big5-HKSCS EUC-TW EUC-JP ISO-2022-JP Shift_JIS EUC-KR)
     def initialize(objects = [], schema = {})
       return self if (@objects = objects).blank?

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -32,10 +32,23 @@ describe RailsAdmin::CSVConverter do
 
     subject { RailsAdmin::CSVConverter.new(objects, schema).to_csv(encoding_to: encoding) }
 
+    context 'when encoding FROM MySQL utf8mb4' do
+      let(:encoding) { 'UTF-8' }  # default
+
+      it 'exports to UTF-8 with BOM' do
+        # MySQL connection may report its encoding as 'utf8mb4'
+        expect(::ActiveRecord::Base.connection).to receive(:encoding) { 'utf8mb4' }
+        expect(subject[1]).to eq 'UTF-8'
+        expect(subject[2].encoding).to eq Encoding::UTF_8
+        expect(subject[2].unpack('H*').first).
+          to eq 'efbbbf4e756d6265722c4e616d650a312ce381aae381bee381880a'  # have BOM
+      end
+    end
+
     context 'when encoding to UTF-8' do
       let(:encoding) { 'UTF-8' }
 
-      it 'exports to UTR-8 with BOM' do
+      it 'exports to UTF-8 with BOM' do
         expect(subject[1]).to eq 'UTF-8'
         expect(subject[2].encoding).to eq Encoding::UTF_8
         expect(subject[2].unpack('H*').first).

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -35,7 +35,7 @@ describe RailsAdmin::CSVConverter do
     context 'when encoding FROM MySQL utf8mb4' do
       let(:encoding) { 'UTF-8' }  # default
 
-      it 'exports to UTF-8 with BOM' do
+      it 'exports to UTF-8 with BOM', active_record: true do
         # MySQL connection may report its encoding as 'utf8mb4'
         expect(::ActiveRecord::Base.connection).to receive(:encoding) { 'utf8mb4' }
         expect(subject[1]).to eq 'UTF-8'


### PR DESCRIPTION
MySQL's default UTF-8 encoding is limited to 3-byte characters and
the encoding it uses and reports for full 4-byte Unicode is called
'utf8mb4' but if the database reports this encoding, the CSV export
module would try to convert string encodings utf8mb4 -> utf8,
causing an error.
Obviously the former is not a valid encoding name in Ruby, but is
actually going to be UTF-8, so this change assumes it's already
UTF-8.