### PR TITLE
Fix csv for utf8mb4

### DIFF
--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -3,7 +3,7 @@ require 'csv'
 
 module RailsAdmin
   class CSVConverter
-    UTF8_ENCODINGS = [nil, '', 'utf8', 'utf-8', 'unicode', 'UTF8', 'UTF-8', 'UNICODE']
+    UTF8_ENCODINGS = [nil, '', 'utf8', 'utf-8', 'unicode', 'UTF8', 'UTF-8', 'UNICODE', 'utf8mb4']
     TARGET_ENCODINGS = %w(UTF-8 UTF-16LE UTF-16BE UTF-32LE UTF-32BE UTF-7 ISO-8859-1 ISO-8859-15 IBM850 MacRoman Windows-1252 ISO-8859-3 IBM852 ISO-8859-2 Windows-1250 IBM855 ISO-8859-5 KOI8-R MacCyrillic Windows-1251 IBM866 GB2312 GBK GB18030 Big5 Big5-HKSCS EUC-TW EUC-JP ISO-2022-JP Shift_JIS EUC-KR)
     def initialize(objects = [], schema = {})
       return self if (@objects = objects).blank?

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -64,5 +64,13 @@ describe RailsAdmin::CSVConverter do
           to eq 'feff004e0075006d006200650072002c004e0061006d0065000a0031002c306a307e3048000a'
       end
     end
+
+    context 'when encoding from utf8mb4 to UTF-8' do
+      let(:encoding) { 'UTF-8' }
+      it 'exports to UTF-8' do
+        allow_any_instance_of(RailsAdmin::Adapters::ActiveRecord).to receive(:encoding).and_return('utf8mb4')
+        expect(subject[1]).to eq 'UTF-8'
+      end
+    end
   end
 end

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -35,7 +35,7 @@ describe RailsAdmin::CSVConverter do
     context 'when encoding to UTF-8' do
       let(:encoding) { 'UTF-8' }
 
-      it 'exports to UTR-8 with BOM' do
+      it 'exports to UTF-8 with BOM' do
         expect(subject[1]).to eq 'UTF-8'
         expect(subject[2].encoding).to eq Encoding::UTF_8
         expect(subject[2].unpack('H*').first).


### PR DESCRIPTION
On MySQL, in order to store Emoji in the database, one must use `utf8mb4` encoding. Yet, this encoding was not present in the list of `UTF8_ENCODINGS`, so the export fails with

    ArgumentError: unknown encoding name - utf8mb4