### PR TITLE
Fix checkbox style

### DIFF
--- a/app/views/rails_admin/main/_form_boolean.html.haml
+++ b/app/views/rails_admin/main/_form_boolean.html.haml
@@ -1,0 +1,3 @@
+.checkbox
+  %label{ style: 'display: block;' }
+    = form.send field.view_helper, field.method_name, field.html_attributes.reverse_merge({ value: field.form_value, checked: field.form_value.in?([true, '1']), required: field.required})

--- a/app/views/rails_admin/main/_form_field.html.haml
+++ b/app/views/rails_admin/main/_form_field.html.haml
@@ -1,1 +1,1 @@
-= form.send field.view_helper, field.method_name, field.html_attributes.reverse_merge({ value: field.form_value, checked: field.form_value.in?([true, '1']), class: 'form-control', required: field.required})
+= form.send field.view_helper, field.method_name, field.html_attributes.reverse_merge({ value: field.form_value, class: 'form-control', required: field.required})

--- a/lib/rails_admin/config/fields/types/boolean.rb
+++ b/lib/rails_admin/config/fields/types/boolean.rb
@@ -25,6 +25,10 @@ module RailsAdmin
             value.inspect
           end
 
+          register_instance_option :partial do
+            :form_boolean
+          end
+
           # Accessor for field's help text displayed below input field.
           def generic_help
             ''


### PR DESCRIPTION
Remove checked option from generic form field
Add boolean field partial

**Please take a deeper look at this PR** because I added a new partial and removed the `checked` option from the generic field. I also need to set some custom css to avoid another label

The error is due to the `form-control` class currently added to the checkbox input

### Before
![screen shot 2015-04-27 at 21 43 04](https://cloud.githubusercontent.com/assets/556268/7356165/b1eb5c70-ed26-11e4-80d6-8071a268189b.png)

### After
![screen shot 2015-04-27 at 21 42 16](https://cloud.githubusercontent.com/assets/556268/7356173/ca324ab4-ed26-11e4-9550-e7a272140497.png)
