### PR TITLE
Set minimum Sass precision to 8

### DIFF
--- a/lib/rails_admin/bootstrap-sass.rb
+++ b/lib/rails_admin/bootstrap-sass.rb
@@ -19,6 +19,7 @@ module RailsAdmin
 
       stylesheets = File.expand_path(File.join('..', 'vendor', 'assets', 'stylesheets'))
       ::Sass.load_paths << stylesheets
+      ::Sass::Script::Value::Number.precision = [8, ::Sass::Script::Value::Number.precision].max
     end
 
   private


### PR DESCRIPTION
Bootstrap requires a [minimum sass precision of 8](https://github.com/twbs/bootstrap-sass#sass-number-precision)

This is causing some issues on button height. In example, if you try to append buttons to form controls the result will be 1px wrong

### Before
![screen shot 2015-04-27 at 22 41 32](https://cloud.githubusercontent.com/assets/556268/7357512/85389fd6-ed2f-11e4-816c-f4d69dfc2674.png)

### After
![screen shot 2015-04-27 at 22 46 11](https://cloud.githubusercontent.com/assets/556268/7357533/a7ae0b64-ed2f-11e4-9edc-a06ec65fe7f4.png)

(I'm trying to update the dropdown, but it seems I opened Pandora's box :grin:)
