### PR TITLE
Flash bootstrap alert styles

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -115,7 +115,7 @@ module RailsAdmin
 
     def check_for_cancel
       return unless params[:_continue] || (params[:bulk_action] && !params[:bulk_ids])
-      redirect_to(back_or_index, flash: {info: t('admin.flash.noaction')})
+      redirect_to(back_or_index, notice: t('admin.flash.noaction'))
     end
 
     def get_collection(model_config, scope, pagination)

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -161,5 +161,14 @@ module RailsAdmin
           end
       end.html_safe
     end
+
+    def flash_alert_class(flash_key)
+      case flash_key.to_s
+      when 'error'; 'alert-danger'
+      when 'alert'; 'alert-warning'
+      when 'notice'; 'alert-info'
+      else "alert-#{flash_key}"
+      end
+    end
   end
 end

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -164,9 +164,9 @@ module RailsAdmin
 
     def flash_alert_class(flash_key)
       case flash_key.to_s
-      when 'error'; 'alert-danger'
-      when 'alert'; 'alert-warning'
-      when 'notice'; 'alert-info'
+      when 'error'  then 'alert-danger'
+      when 'alert'  then 'alert-warning'
+      when 'notice' then 'alert-info'
       else "alert-#{flash_key}"
       end
     end

--- a/app/views/layouts/rails_admin/pjax.html.haml
+++ b/app/views/layouts/rails_admin/pjax.html.haml
@@ -6,8 +6,7 @@
 .page-header
   %h1= @page_name
 - flash && flash.each do |key, value|
-  - key = 'danger' if key.to_s == 'error'
-  .alert{class: "alert-#{key}"}
+  .alert{class: flash_alert_class(key)}
     %a.close{href: '#', :'data-dismiss' => "alert"} &times;
     = value
 = breadcrumb

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -378,4 +378,19 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#flash_alert_class' do
+    it 'makes errors red with alert-danger' do
+      expect(helper.flash_alert_class('error')).to eq('alert-danger')
+    end
+    it 'makes alerts yellow with alert-warning' do
+      expect(helper.flash_alert_class('alert')).to eq('alert-warning')
+    end
+    it 'makes notices blue with alert-info' do
+      expect(helper.flash_alert_class('notice')).to eq('alert-info')
+    end
+    it 'prefixes others with "alert-"' do
+      expect(helper.flash_alert_class('foo')).to eq('alert-foo')
+    end
+  end
 end


### PR DESCRIPTION
This patch allows `redirect_to foo_path, notice: 'bar'` to show a coloured alert box rather than plain text.

Rails has some standard and commonly used flash keys, notice and alert, and some shortcuts to interact with them. But if you use them in Rails Admin, as in [this custom action tutorial](http://blog.endpoint.com/2012/03/railsadmin-custom-action-case-study.html), you'll need to add custom CSS for the `alert-notice` class, or else you must replace the standard Rails keys with the alert names from Bootstrap: `flash: {info: '...'}` instead of just `notice: '...'`

In the same way as Rails Admin already mapped the flash key 'error' to 'alert-danger' to give a red box, this patch additionally maps 'notice' to 'alert-info' for a blue box, and 'alert' to 'alert-warning' for a yellow box.