### PR TITLE
Fields with same names but new types should be placed in the original position

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -21,11 +21,11 @@ module RailsAdmin
         elsif type && type != (field.nil? ? nil : field.type)
           if field
             properties = field.properties
-            _fields.delete(field)
+            field = _fields[_fields.index(field)] = RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)
           else
             properties = abstract_model.properties.detect { |p| name == p.name }
+            field = (_fields <<  RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)).last
           end
-          field = (_fields << RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)).last
         end
 
         # If field has not been yet defined add some default properties


### PR DESCRIPTION
Fields, with the same names but different types shouldn't always be put at the bottom. 

For example, I have a couple fields in the middle of my form, :state and :state_updated_at as a pair of related fields. :state has a type as :string by default, but I would like to make it as :enum. Configuring the :state field will separate two fields and make :state appear at the bottom.