### PR TITLE
fix wysihtml5 asset path

### DIFF
--- a/lib/rails_admin/config/fields/types/wysihtml5.rb
+++ b/lib/rails_admin/config/fields/types/wysihtml5.rb
@@ -16,11 +16,11 @@ module RailsAdmin
           end
 
           register_instance_option :css_location do
-            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5.css')
+            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5/index.css')
           end
 
           register_instance_option :js_location do
-            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5.js')
+            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5/index.js')
           end
 
           register_instance_option :partial do


### PR DESCRIPTION
fix path for use in production with rails 4.2 and last spockets
```
Asset was linked to from an alias rather than its exact path. Alias resolving may not be available in production. Use "bootstrap-wysihtml5/index.css" instead of "bootstrap-wysihtml5.css"
Asset was linked to from an alias rather than its exact path. Alias resolving may not be available in production. Use "bootstrap-wysihtml5/index.js" instead of "bootstrap-wysihtml5.js"
```