### PR TITLE
allow to retrieve a scoped index from a polymorphic lazyloaded association

### DIFF
--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -27,7 +27,14 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-            @objects ||= list_entries
+            if params[:additional_scope]
+              associated_model = RailsAdmin::AbstractModel.new(params[:additional_scope][:model])
+              associated_config = associated_model.config
+              field = associated_config.field(params[:additional_scope][:association].to_sym).with(object: associated_model.model.find(params[:additional_scope][:model_id]))
+              @objects ||= list_entries(@model_config, :index, field.associated_collection_scope)
+            else
+              @objects ||= list_entries
+            end
 
             unless @model_config.list.scopes.empty?
               if params[:scope].blank?

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -207,16 +207,15 @@ describe RailsAdmin::MainController, type: :controller do
     it 'scopes polymorphic associations' do
       player_one = FactoryGirl.create :player
       player_two = FactoryGirl.create :player
-      2.times.collect do
+      2.times do
         FactoryGirl.create :comment, commentable: player_one
       end
-      4.times.collect do
+      4.times do
         FactoryGirl.create :comment, commentable: player_two
       end
 
       RailsAdmin.config Comment do
         field :commentable do
-
           associated_collection_scope do
             comment = bindings[:object]
             proc { |scope| scope.where(commentable_id: comment.commentable_id) }
@@ -224,7 +223,7 @@ describe RailsAdmin::MainController, type: :controller do
         end
       end
 
-      get :index, model_name: "comment", format: :json, additional_scope: { association: "commentable", model: "Comment", model_id: Comment.last.id}
+      get :index, model_name: 'comment', format: :json, additional_scope: {association: 'commentable', model: 'Comment', model_id: Comment.last.id}
       expect(JSON.parse(response.body).size).to eq(4)
     end
 

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -204,6 +204,30 @@ describe RailsAdmin::MainController, type: :controller do
       expect(controller.list_entries.to_a.length).to eq(@team.revenue.to_i)
     end
 
+    it 'scopes polymorphic associations' do
+      player_one = FactoryGirl.create :player
+      player_two = FactoryGirl.create :player
+      2.times.collect do
+        FactoryGirl.create :comment, commentable: player_one
+      end
+      4.times.collect do
+        FactoryGirl.create :comment, commentable: player_two
+      end
+
+      RailsAdmin.config Comment do
+        field :commentable do
+
+          associated_collection_scope do
+            comment = bindings[:object]
+            proc { |scope| scope.where(commentable_id: comment.commentable_id) }
+          end
+        end
+      end
+
+      get :index, model_name: "comment", format: :json, additional_scope: { association: "commentable", model: "Comment", model_id: Comment.last.id}
+      expect(JSON.parse(response.body).size).to eq(4)
+    end
+
     it 'limits associated collection records number to 30 if cache_all is false' do
       @players = FactoryGirl.create_list(:player, 40)
 


### PR DESCRIPTION
in the view, we have two dropdowns to select type and object in a polymorphic belongs_to association.
with these changes you have the ability to configure a scope on the association instead of always retrieving all objects of the selected type
