### PR TITLE
Improve navbar

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -3,6 +3,8 @@
   Keep it clean, people
 */
 
+$avatar-size: 30px;
+
 body.rails_admin {
 
   .thumbnail {
@@ -12,12 +14,18 @@ body.rails_admin {
   /* room for upper navbar */
   padding-top: $navbar-height;
 
-  /* Application name */
-  .navbar .brand {
-    small {
-      color:#9d261d;
-      font-weight:bold;
-      line-height: 1;
+  .navbar {
+    .edit_user_root_link {
+      position: relative;
+
+      img {
+        position: absolute;
+        top: ((40px - $avatar-size) / 2);
+
+        & + span {
+          margin-left: ($avatar-size + 5px);
+        }
+      }
     }
   }
 
@@ -284,8 +292,16 @@ body.rails_admin {
   }
 }
 
-@media screen and (min-width: $screen-sm-min) {
+@media screen and (min-width: $grid-float-breakpoint) {
   body.rails_admin {
+    .navbar {
+      .edit_user_root_link {
+        img {
+          top: (($navbar-height - $avatar-size) / 2);
+        }
+      }
+    }
+
     .sidebar-nav {
       position: fixed;
       top: $navbar-height;

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -35,7 +35,12 @@ module RailsAdmin
       return nil unless _current_user.respond_to?(:email)
       return nil unless abstract_model = RailsAdmin.config(_current_user.class).abstract_model
       return nil unless (edit_action = RailsAdmin::Config::Actions.find(:edit, controller: controller, abstract_model: abstract_model, object: _current_user)).try(:authorized?)
-      link_to _current_user.email, url_for(action: edit_action.action_name, model_name: abstract_model.to_param, id: _current_user.id, controller: 'rails_admin/main')
+      link_to url_for(action: edit_action.action_name, model_name: abstract_model.to_param, id: _current_user.id, controller: 'rails_admin/main') do
+        html = []
+        html << image_tag("#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", alt: '') if _current_user.email.present?
+        html << content_tag(:span, _current_user.email)
+        html.join.html_safe
+      end
     end
 
     def logout_path

--- a/app/views/layouts/rails_admin/_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_navigation.html.haml
@@ -1,7 +1,12 @@
 .container-fluid
   .navbar-header
+    %button.navbar-toggle.collapsed{ type: 'button', data: { toggle: 'collapse', target: '#secondary-navigation' } }
+      %span.sr-only= t('admin.toggle_navigation')
+      %span.icon-bar
+      %span.icon-bar
+      %span.icon-bar
     %a.navbar-brand.pjax{href: dashboard_path}
       = _get_plugin_name[0] || 'Rails'
       %small= _get_plugin_name[1] || 'Admin'
-  .collapse.navbar-collapse
+  .collapse.navbar-collapse#secondary-navigation
     = render partial: 'layouts/rails_admin/secondary_navigation'

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -5,8 +5,6 @@
     %li= link_to t('admin.home.name'), main_app_root_path
   - if _current_user
     - if user_link = edit_user_link
-      %li= user_link
+      %li.edit_user_root_link= user_link
     - if logout_path.present?
       %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-danger'), logout_path, method: logout_method
-    - if _current_user.respond_to?(:email) && _current_user.email.present?
-      %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", style: 'padding-top:5px'

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -17,6 +17,7 @@ en:
       starts_with: Starts with
       ends_with: Ends with
     loading: "Loading..."
+    toggle_navigation: Toggle navigation
     home:
       name: "Home"
     pagination:


### PR DESCRIPTION
Moves gravatar near user email
Removes alt attribute from gravatar (useless md5 encoded email)
Also adds support for collapsed navbar

### Before
![screen shot 2015-05-27 at 18 20 49](https://cloud.githubusercontent.com/assets/556268/7842341/e9c8824c-04a2-11e5-97f6-d44e466a1787.png)


### After
![screen shot 2015-05-27 at 18 56 25](https://cloud.githubusercontent.com/assets/556268/7842359/f08e84d2-04a2-11e5-8154-9d2453b63d7c.png)

![screen shot 2015-05-27 at 18 56 44](https://cloud.githubusercontent.com/assets/556268/7842367/f80fef70-04a2-11e5-8f7c-029b19f56f11.png)
