### PR TITLE
Fix devise specs for :devise_scope compatibility

### DIFF
--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -127,13 +127,13 @@ describe RailsAdmin, type: :request do
     it "does not show Gravatar when user doesn't have email method" do
       allow_any_instance_of(User).to receive(:respond_to?).and_return(true)
       allow_any_instance_of(User).to receive(:respond_to?).with(:email).and_return(false)
+      allow_any_instance_of(User).to receive(:respond_to?).with(:devise_scope).and_return(false)
       visit dashboard_path
       is_expected.not_to have_selector('ul.nav.pull-right li img')
     end
 
     it 'does not cause error when email is nil' do
-      allow_any_instance_of(User).to receive(:respond_to?).and_return(true)
-      allow_any_instance_of(User).to receive(:respond_to?).with(:email).and_return(nil)
+      allow_any_instance_of(User).to receive(:email).and_return(nil)
       visit dashboard_path
       is_expected.to have_selector('body.rails_admin')
     end


### PR DESCRIPTION
Devise 3.5.1 allows objects to specify their devise scope https://github.com/plataformatec/devise/commit/4837bb0a4e5a1ea00e732f48ee2acef90606a31e

So if we add `allow_any_instance_of(User).to receive(:respond_to?).and_return(true)` this will respond `true` here: https://github.com/plataformatec/devise/blob/4837bb0a4e5a1ea00e732f48ee2acef90606a31e/lib/devise/mapping.rb#L34

and the specs will fail.

Moreover, afaik, `respond_to?` should answer with `true` or `false` and this spec

```rb
    it 'does not cause error when email is nil' do
      allow_any_instance_of(User).to receive(:respond_to?).and_return(true)
      allow_any_instance_of(User).to receive(:respond_to?).with(:email).and_return(nil)
```

is doing something else. I think it was supposed to `allow_any_instance_of(User).to receive(:email).and_return(nil)`