### PR TITLE
Fix nested form controls

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -107,6 +107,11 @@ body.rails_admin {
       display:block;
     }
 
+    /* Put form controls above siblings to make them accessible */
+    .controls {
+      z-index: 1;
+    }
+
     /* nested forms */
     .tab-content {
       .tab-pane {


### PR DESCRIPTION
As of #2313, you cannot switch between multiple objects as the content tab is above the controls.
![rails_admin_nested_form](https://cloud.githubusercontent.com/assets/2334782/7912851/d04c215c-0862-11e5-8dd6-16cfb1d262d8.jpg)
So in the form above I cannot change to the previous tab (unless I delete the active one)