### PR TITLE
Included missing Bootstrap panels scss and added missing bottom margi…

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -191,8 +191,12 @@ body.rails_admin {
   }
 
   /* tab links should match icon color */
-  .nav.nav-tabs li.icon a {
-    color: #000;
+  .nav.nav-tabs {
+    margin-bottom: 20px;
+
+    li.icon a {
+      color: #000;
+    }
   }
 
   /* Table cells behaviour */

--- a/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
+++ b/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
@@ -90,6 +90,7 @@
 @import "rails_admin/bootstrap/popovers";
 @import "rails_admin/bootstrap/thumbnails";
 @import "rails_admin/bootstrap/labels";
+@import "rails_admin/bootstrap/panels";
 @import "rails_admin/bootstrap/badges";
 @import "rails_admin/bootstrap/progress-bars";
 <%# @import "rails_admin/bootstrap/accordion"; %>


### PR DESCRIPTION
…n to the nav tabs

Will fix #2282 and makes the filter "well" under the nav tabs sit like they used to in earlier versions of rails_admin (i.e. not touching).

Before:

![before](https://cloud.githubusercontent.com/assets/1147871/8069920/ab60a9a0-0ef5-11e5-91e2-94af68cb0e72.png)

After:

![after](https://cloud.githubusercontent.com/assets/1147871/8069947/cf6cb94c-0ef5-11e5-90b9-487569857447.png)

