### PR TITLE
Do not monkey patch the app's YAML

### DIFF
--- a/lib/rails_admin/config/fields/types/serialized.rb
+++ b/lib/rails_admin/config/fields/types/serialized.rb
@@ -14,7 +14,7 @@ module RailsAdmin
 
           def parse_input(params)
             return unless params[name].is_a?(::String)
-            params[name] = (params[name].blank? ? nil : (YAML.safe_load(params[name]) || nil))
+            params[name] = (params[name].blank? ? nil : (SafeYAML.load(params[name]) || nil))
           end
         end
       end

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -7,10 +7,7 @@ require 'rack-pjax'
 require 'rails'
 require 'rails_admin'
 require 'remotipart'
-require 'safe_yaml'
-
-SafeYAML::OPTIONS[:suppress_warnings] = true
-SafeYAML::OPTIONS[:default_mode] = :unsafe
+require 'safe_yaml/load'
 
 module RailsAdmin
   class Engine < Rails::Engine


### PR DESCRIPTION
SafeYAML provides a way to avoid monkey-patching the `YAML` object. This
should be used to avoid overwriting the application's `YAML`.

This was causing problems with our application, which uses Psych's `YAML.safe_load` method in ways that are incompatible with SafeYAML's implementation. It's important to note that `YAML.safe_load` has existed in Ruby's stdlib [since 2.1.0][1].

[1]: http://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load