### PR TITLE
Fix css regression for has_one and has_many nested form

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -114,6 +114,8 @@ body.rails_admin {
 
     /* nested forms */
     .tab-content {
+      clear: both;
+
       .tab-pane {
         @include clearfix;
         border-left: 5px solid #049cdb;


### PR DESCRIPTION
Re-establish the margin below the has_may/has_one button as the boostrap2 version

##### Before
![screenshot from 2015-06-19 19 07 10](https://cloud.githubusercontent.com/assets/56606/8258776/ffa05e92-16b7-11e5-8de6-f6e426576af7.png)

##### After
![screenshot from 2015-06-19 19 15 32](https://cloud.githubusercontent.com/assets/56606/8258777/00e2f04e-16b8-11e5-9599-d6ddcf6e6b77.png)