### PR TITLE
Change: make browser validations configurable via DSL

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -3,7 +3,11 @@ require 'builder'
 module RailsAdmin
   module MainHelper
     def rails_admin_form_for(*args, &block)
-      options = args.extract_options!.reverse_merge(builder: RailsAdmin::FormBuilder)
+      options = args.extract_options!.reverse_merge(
+        html: {novalidate: !RailsAdmin::Config.browser_validations},
+        builder: RailsAdmin::FormBuilder,
+      )
+
       form_for(*(args << options), &block) << after_nested_form_callbacks
     end
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -50,7 +50,7 @@ module RailsAdmin
       # hide blank fields in show view if true
       attr_accessor :compact_show_view
 
-      #  Enable HTML5 browser validation
+      # Tell browsers whether to use the native HTML5 validations (novalidate form option).
       attr_accessor :browser_validations
 
       # Set the max width of columns in list view before a new set is created

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -50,6 +50,9 @@ module RailsAdmin
       # hide blank fields in show view if true
       attr_accessor :compact_show_view
 
+      #  Enable HTML5 browser validation
+      attr_accessor :browser_validations
+
       # Set the max width of columns in list view before a new set is created
       attr_accessor :total_columns_width
 
@@ -254,6 +257,7 @@ module RailsAdmin
       # @see RailsAdmin::Config.registry
       def reset
         @compact_show_view = true
+        @browser_validations = true
         @yell_for_non_accessible_fields = true
         @authenticate = nil
         @authorize = nil

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -123,8 +123,14 @@ module RailsAdmin
           (@help ||= {})[::I18n.locale] ||= generic_field_help
         end
 
+        def html_required?
+          RailsAdmin::Config.browser_validations && required
+        end
+
         register_instance_option :html_attributes do
-          {}
+          {
+            required: html_required?,
+          }
         end
 
         register_instance_option :default_value do

--- a/lib/rails_admin/config/fields/types/string.rb
+++ b/lib/rails_admin/config/fields/types/string.rb
@@ -7,10 +7,15 @@ module RailsAdmin
         class String < RailsAdmin::Config::Fields::Base
           RailsAdmin::Config::Fields::Types.register(self)
 
+          def input_size
+            [50, length.to_i].reject(&:zero?).min
+          end
+
           register_instance_option :html_attributes do
             {
+              required: html_required?,
               maxlength: length,
-              size: [50, length.to_i].reject(&:zero?).min,
+              size: input_size,
             }
           end
 

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -28,6 +28,7 @@ module RailsAdmin
 
           register_instance_option :html_attributes do
             {
+              required: html_required?,
               cols: '48',
               rows: '3',
             }

--- a/spec/helpers/rails_admin/main_helper_spec.rb
+++ b/spec/helpers/rails_admin/main_helper_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe RailsAdmin::MainHelper, type: :helper do
+  describe '#rails_admin_form_for' do
+    let(:html_form) do
+      helper.rails_admin_form_for(FieldTest.new, url: new_path(model_name: 'field_test')) {}
+    end
+
+    context 'with html5 browser_validations enabled' do
+      before do
+        RailsAdmin.config.browser_validations = true
+        RailsAdmin.config FieldTest do
+          field :address, :string do
+            required true
+          end
+        end
+      end
+
+      it 'should not add novalidate attribute to the html form tag' do
+        expect(html_form).to_not include 'novalidate'
+      end
+    end
+
+    context 'with html5 browser_validations disabled' do
+      before do
+        RailsAdmin.config.browser_validations = false
+        RailsAdmin.config FieldTest do
+          field :address, :string do
+            required true
+          end
+        end
+      end
+
+      it 'should add novalidate attribute to the html form tag' do
+        expect(html_form).to include "novalidate=\"novalidate\""
+      end
+    end
+  end
+end

--- a/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
@@ -5,6 +5,7 @@ describe 'RailsAdmin Basic Edit', type: :request do
 
   describe 'edit' do
     before do
+      RailsAdmin::Config.browser_validations = true
       @player = FactoryGirl.create :player
       visit edit_path(model_name: 'player', id: @player.id)
     end
@@ -25,12 +26,12 @@ describe 'RailsAdmin Basic Edit', type: :request do
     end
 
     it 'checks required fields to have required attribute set' do
-      expect(find_field('player_name')[:required].nil?).to eq(false)
-      expect(find_field('player_number')[:required].nil?).to eq(false)
+      expect(find_field('player_name')[:required]).to be_present
+      expect(find_field('player_number')[:required]).to be_present
     end
 
     it 'checks optional fields to not have required attribute set' do
-      expect(find_field('player_position')[:required].nil?).to eq(true)
+      expect(find_field('player_position')[:required]).to be_blank
     end
   end
 

--- a/spec/rails_admin/config/fields/types/belongs_to_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/belongs_to_association_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::BelongsToAssociation do
+  it_behaves_like 'a generic field type', :integer_field, :belongs_to_association
+end

--- a/spec/rails_admin/config/fields/types/boolean_spec.rb
+++ b/spec/rails_admin/config/fields/types/boolean_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Boolean do
+  it_behaves_like 'a generic field type', :boolean_field, :boolean
+end

--- a/spec/rails_admin/config/fields/types/bson_object_id_spec.rb
+++ b/spec/rails_admin/config/fields/types/bson_object_id_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::BsonObjectId do
+  it_behaves_like 'a generic field type', :string_field, :bson_object_id
+end

--- a/spec/rails_admin/config/fields/types/carrierwave_spec.rb
+++ b/spec/rails_admin/config/fields/types/carrierwave_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Carrierwave do
+  it_behaves_like 'a generic field type', :string_field, :carrierwave
+end

--- a/spec/rails_admin/config/fields/types/ck_editor_spec.rb
+++ b/spec/rails_admin/config/fields/types/ck_editor_spec.rb
@@ -21,4 +21,6 @@ describe RailsAdmin::Config::Fields::Types::CKEditor do
       ).to eq @custom_prefix
     end
   end
+
+  it_behaves_like 'a generic field type', :text_field, :ck_editor
 end

--- a/spec/rails_admin/config/fields/types/code_mirror_spec.rb
+++ b/spec/rails_admin/config/fields/types/code_mirror_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::CodeMirror do
+  it_behaves_like 'a generic field type', :text_field, :code_mirror
+end

--- a/spec/rails_admin/config/fields/types/color_spec.rb
+++ b/spec/rails_admin/config/fields/types/color_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Color do
+  it_behaves_like 'a generic field type', :string_field, :color
+end

--- a/spec/rails_admin/config/fields/types/date_spec.rb
+++ b/spec/rails_admin/config/fields/types/date_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Date do
+  it_behaves_like 'a generic field type', :date_field, :date
+end

--- a/spec/rails_admin/config/fields/types/datetime_spec.rb
+++ b/spec/rails_admin/config/fields/types/datetime_spec.rb
@@ -15,4 +15,6 @@ describe RailsAdmin::Config::Fields::Types::Datetime do
       expect(RailsAdmin.config(FieldTest).fields.detect { |f| f.name == :datetime_field }.with(object: FieldTest.new).formatted_date_value).to eq 'January 01, 2012'
     end
   end
+
+  it_behaves_like 'a generic field type', :datetime_field, :datetime
 end

--- a/spec/rails_admin/config/fields/types/decimal_spec.rb
+++ b/spec/rails_admin/config/fields/types/decimal_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Decimal do
+  it_behaves_like 'a generic field type', :decimal_field, :decimal
+end

--- a/spec/rails_admin/config/fields/types/drangonfly_spec.rb
+++ b/spec/rails_admin/config/fields/types/drangonfly_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Dragonfly do
+  it_behaves_like 'a generic field type', :string_field, :dragonfly
+end

--- a/spec/rails_admin/config/fields/types/enum_spec.rb
+++ b/spec/rails_admin/config/fields/types/enum_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Enum do
+  it_behaves_like 'a generic field type', :string_field, :enum
+end

--- a/spec/rails_admin/config/fields/types/file_upload_spec.rb
+++ b/spec/rails_admin/config/fields/types/file_upload_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::FileUpload do
+  it_behaves_like 'a generic field type', :string_field, :file_upload
+end

--- a/spec/rails_admin/config/fields/types/float_spec.rb
+++ b/spec/rails_admin/config/fields/types/float_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Float do
+  it_behaves_like 'a generic field type', :float_field, :float
+end

--- a/spec/rails_admin/config/fields/types/froala_spec.rb
+++ b/spec/rails_admin/config/fields/types/froala_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Froala do
+  it_behaves_like 'a generic field type', :text_field, :froala
+end

--- a/spec/rails_admin/config/fields/types/has_and_belongs_to_many_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_and_belongs_to_many_association_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::HasAndBelongsToManyAssociation do
+  it_behaves_like 'a generic field type', :integer_field, :has_and_belongs_to_many_association
+end

--- a/spec/rails_admin/config/fields/types/has_many_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_many_association_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::HasManyAssociation do
+  it_behaves_like 'a generic field type', :integer_field, :has_many_association
+end

--- a/spec/rails_admin/config/fields/types/has_one_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_one_association_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::HasOneAssociation do
+  it_behaves_like 'a generic field type', :integer_field, :has_one_association
+end

--- a/spec/rails_admin/config/fields/types/hidden_spec.rb
+++ b/spec/rails_admin/config/fields/types/hidden_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Hidden do
+  it_behaves_like 'a generic field type', :integer_field, :hidden
+end

--- a/spec/rails_admin/config/fields/types/inet_spec.rb
+++ b/spec/rails_admin/config/fields/types/inet_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Inet do
+  it_behaves_like 'a generic field type', :string_field, :inet
+end

--- a/spec/rails_admin/config/fields/types/integer_spec.rb
+++ b/spec/rails_admin/config/fields/types/integer_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Integer do
+  it_behaves_like 'a generic field type', :integer_field, :integer
+end

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -35,4 +35,6 @@ describe RailsAdmin::Config::Fields::Types::Json do
       expect(field.class).to eq RailsAdmin::Config::Fields::Types::Json
     end
   end
+
+  it_behaves_like 'a generic field type', :text, :json
 end

--- a/spec/rails_admin/config/fields/types/paperclip_spec.rb
+++ b/spec/rails_admin/config/fields/types/paperclip_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Paperclip do
+  it_behaves_like 'a generic field type', :string_field, :paperclip
+end

--- a/spec/rails_admin/config/fields/types/password_spec.rb
+++ b/spec/rails_admin/config/fields/types/password_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Password do
+  it_behaves_like 'a generic field type', :string_field, :password
+end

--- a/spec/rails_admin/config/fields/types/serialized_spec.rb
+++ b/spec/rails_admin/config/fields/types/serialized_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Serialized do
+  it_behaves_like 'a generic field type', :text_field, :serialized
+end

--- a/spec/rails_admin/config/fields/types/string_spec.rb
+++ b/spec/rails_admin/config/fields/types/string_spec.rb
@@ -22,4 +22,6 @@ describe RailsAdmin::Config::Fields::Types::String do
       expect(string_field.html_attributes[:size]).to_not be_zero
     end
   end
+
+  it_behaves_like 'a generic field type', :string_field, :string
 end

--- a/spec/rails_admin/config/fields/types/text_spec.rb
+++ b/spec/rails_admin/config/fields/types/text_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Text do
+  it_behaves_like 'a generic field type', :text_field, :text
+end

--- a/spec/rails_admin/config/fields/types/time_spec.rb
+++ b/spec/rails_admin/config/fields/types/time_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Time do
+  it_behaves_like 'a generic field type', :time_field, :time
+end

--- a/spec/rails_admin/config/fields/types/uuid_spec.rb
+++ b/spec/rails_admin/config/fields/types/uuid_spec.rb
@@ -24,4 +24,6 @@ describe RailsAdmin::Config::Fields::Types::Uuid do
   it 'handles uuid string' do
     expect(@field.value).to eq uuid
   end
+
+  it_behaves_like 'a generic field type', :string_field, :uuid
 end

--- a/spec/rails_admin/config/fields/types/wysihtml5_spec.rb
+++ b/spec/rails_admin/config/fields/types/wysihtml5_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe RailsAdmin::Config::Fields::Types::Wysihtml5 do
+  it_behaves_like 'a generic field type', :text_field, :wysihtml5
+end

--- a/spec/shared_examples/shared_examples_for_field_types.rb
+++ b/spec/shared_examples/shared_examples_for_field_types.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'a generic field type' do |column_name, field_type|
+  context 'with browser_validations' do
+    before do
+      RailsAdmin.config FieldTest do
+        field column_name, field_type do
+          required true
+        end
+      end
+    end
+
+    let :rails_admin_field do
+      RailsAdmin.config('FieldTest').fields.detect do |f|
+        f.name == column_name
+      end.with(object: FieldTest.new)
+    end
+
+    context 'enabled' do
+      before :each do
+        RailsAdmin::Config.browser_validations = true
+      end
+
+      describe '#html_attributes' do
+        it 'should contain a required attribute with the string "required" as value' do
+          expect(rails_admin_field.html_attributes[:required]).to be_truthy
+        end
+      end
+    end
+
+    context 'disabled' do
+      before :each do
+        RailsAdmin::Config.browser_validations = false
+      end
+
+      describe '#html_attributes' do
+        it 'should contain a required attribute with the string "required" as value' do
+          expect(rails_admin_field.html_attributes[:required]).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ require 'factories'
 require 'database_cleaner'
 require "orm/#{CI_ORM}"
 
+Dir[File.expand_path('../shared_examples/**/*.rb', __FILE__)].each { |f| require f }
+
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true
 ActionMailer::Base.default_url_options[:host] = 'example.com'


### PR DESCRIPTION
Add the ability to enable/disable html5 browser validations through:

```ruby
RailsAdmin.config do |config|
  config.browser_validations = true
end
```