### PR TITLE
Fix: remove wrong class `.image_field`

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -70,7 +70,7 @@ body.rails_admin {
       display:none;
     }
 
-    .control-group.image_field {
+    .control-group {
       .img-thumbnail {
         margin-bottom: 10px;
       }


### PR DESCRIPTION
I made a mistake adding the class `.image_field` which is related to a table column `image`.