### PR TITLE
Fix: novalidate attribute merging 

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -3,20 +3,18 @@ require 'builder'
 module RailsAdmin
   module MainHelper
     def rails_admin_form_for(*args, &block)
-      options = args.extract_options!.reverse_merge(
-        html: {novalidate: !RailsAdmin::Config.browser_validations},
-        builder: RailsAdmin::FormBuilder,
-      )
+      options = args.extract_options!.reverse_merge(builder: RailsAdmin::FormBuilder)
+      (options[:html] ||= {})[:novalidate] ||= !RailsAdmin::Config.browser_validations
 
       form_for(*(args << options), &block) << after_nested_form_callbacks
     end
 
     def get_indicator(percent)
       return '' if percent < 0          # none
-      return 'info' if percent < 34   # < 1/100 of max
+      return 'info' if percent < 34     # < 1/100 of max
       return 'success' if percent < 67  # < 1/10 of max
       return 'warning' if percent < 84  # < 1/3 of max
-      'danger'                # > 1/3 of max
+      'danger'                          # > 1/3 of max
     end
 
     def get_column_sets(properties)

--- a/spec/helpers/rails_admin/main_helper_spec.rb
+++ b/spec/helpers/rails_admin/main_helper_spec.rb
@@ -6,6 +6,10 @@ describe RailsAdmin::MainHelper, type: :helper do
       helper.rails_admin_form_for(FieldTest.new, url: new_path(model_name: 'field_test')) {}
     end
 
+    let(:html_form_with_attrs) do
+      helper.rails_admin_form_for(FieldTest.new, url: new_path(model_name: 'field_test'), html: {class: 'example'}) {}
+    end
+
     context 'with html5 browser_validations enabled' do
       before do
         RailsAdmin.config.browser_validations = true
@@ -33,6 +37,10 @@ describe RailsAdmin::MainHelper, type: :helper do
 
       it 'should add novalidate attribute to the html form tag' do
         expect(html_form).to include "novalidate=\"novalidate\""
+      end
+
+      it 'should add novalidate attribute to the html form tag with html attributes' do
+        expect(html_form_with_attrs).to include "novalidate=\"novalidate\""
       end
     end
   end


### PR DESCRIPTION
The `novalidate` actually is overrided by `html` rails_admin_form_for options in the rails_admin views.
With this PR the novalidate attribute will be merged into the html options correctly.