### PR TITLE
Add ability to view has_many associations

### DIFF
--- a/app/assets/stylesheets/rails_admin/bootstrap/_labels.scss
+++ b/app/assets/stylesheets/rails_admin/bootstrap/_labels.scss
@@ -26,6 +26,11 @@
     position: relative;
     top: -1px;
   }
+
+  a {
+    color: $label-color;
+    text-decoration: underline;
+  }
 }
 
 // Add hover effects, but only for links

--- a/app/views/rails_admin/main/show.html.haml
+++ b/app/views/rails_admin/main/show.html.haml
@@ -12,5 +12,7 @@
               %dt
                 %span.label.label-info{class: "#{field.type_css_class} #{field.css_class}"}
                   = field.label
+                  - if field.try(:view_url)
+                    %a{href: field.view_url} (#{t('admin.actions.show.view')})
               %dd.well
                 = field.pretty_value

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -73,6 +73,7 @@ en:
         title: "Details for %{model_label} '%{object_label}'"
         menu: "Show"
         breadcrumb: "%{object_label}"
+        view: "View"
       show_in_app:
         menu: "Show in app"
       new:

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -14,6 +14,25 @@ module RailsAdmin
           @properties
         end
 
+        register_instance_option :view_url do
+          current_model = RailsAdmin.config(bindings[:object]).abstract_model.to_param
+          associated_model = associated_model_config.abstract_model.to_param
+
+          # Make sure the appropriate field is available on the associated model,
+          # and that there is more than one value available (if not this view
+          # isn't very helpful)
+          if associated_model_config.fields.map(&:name).include?(current_model.to_sym) &&
+              [value].flatten.size > 1
+            bindings[:view].url_for(
+              action: :index,
+              model_name: associated_model,
+              "f[#{current_model}][1318][o]" => "is",
+              "f[#{current_model}][1318][v]" => bindings[:object].id)
+          else
+            nil
+          end
+        end
+
         register_instance_option :pretty_value do
           v = bindings[:view]
           [value].flatten.select(&:present?).collect do |associated|


### PR DESCRIPTION
I've found it generally useful to be able to view all the `has_many` associations associated with an object.

As a concrete example, in the app I'm working on a user can take video recordings, which are associated with their user account through a `has_many` association. Video files take a while to process after being uploaded, and it's helpful to be able to see the state of all of a user's recordings. Unfortunately, the current default implementation of rails_admin's `association` field type only shows the name of each association, and to find out more details you'd need to click on every associated object. Since in my case a user may have dozens of recordings, this becomes tedious quickly.

This pull request introduces a new `view_url` instance option that, when present in a rails_admin field, adds a link in the field's header on the show page. Additionally, I've created an implementation of this method for the `association` field type that, when more than one associated object is present (and the associated object is registered with rails_admin), leads to a filtered index page for the associated model showing the objects associated with the object in question.

If that didn't make sense, hopefully these screen shots for my `User` and `Recording` class make it clear how this works (the "View" link from the first image leads to the index page seen in the second).

<img width="1056" alt="screen shot 2015-08-13 at 7 50 10 pm" src="https://cloud.githubusercontent.com/assets/176426/9258853/b506a88c-41f5-11e5-8356-9729b885a949.png">

<img width="1054" alt="screen shot 2015-08-13 at 7 50 37 pm" src="https://cloud.githubusercontent.com/assets/176426/9258855/bb27fd6a-41f5-11e5-9079-bdf3f01bc502.png">
