### PR TITLE
Fixed deprecated 'stub from rspec-mocks old :should syntax' warnings

### DIFF
--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -14,7 +14,9 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
   describe '#authorized?' do
     before do
       allow(RailsAdmin.config).to receive(:_current_user).and_return(FactoryGirl.create(:user))
-      helper.controller.stub(:authorization_adapter).and_return(RailsAdmin::AUTHORIZATION_ADAPTERS[:cancan].new(RailsAdmin.config, TestAbility))
+      allow(helper.controller).to receive_message_chain(:authorization_adapter
+        ).and_return(RailsAdmin::AUTHORIZATION_ADAPTERS[:cancan].new(
+        RailsAdmin.config, TestAbility))
     end
 
     it 'doesn\'t test unpersisted objects' do

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -14,9 +14,7 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
   describe '#authorized?' do
     before do
       allow(RailsAdmin.config).to receive(:_current_user).and_return(FactoryGirl.create(:user))
-      allow(helper.controller).to receive_message_chain(:authorization_adapter
-        ).and_return(RailsAdmin::AUTHORIZATION_ADAPTERS[:cancan].new(
-        RailsAdmin.config, TestAbility))
+      allow(helper.controller).to receive_message_chain(:authorization_adapter).and_return(RailsAdmin::AUTHORIZATION_ADAPTERS[:cancan].new(RailsAdmin.config, TestAbility))
     end
 
     it 'doesn\'t test unpersisted objects' do

--- a/spec/rails_admin/config/fields/types/uuid_spec.rb
+++ b/spec/rails_admin/config/fields/types/uuid_spec.rb
@@ -11,7 +11,7 @@ describe RailsAdmin::Config::Fields::Types::Uuid do
     end
 
     @object = FactoryGirl.create(:field_test)
-    @object.stub(:uuid_field).and_return uuid
+    allow(@object).to receive_message_chain(:uuid_field).and_return(uuid)
 
     @field = RailsAdmin.config(FieldTest).fields.detect { |f| f.name == :uuid_field }
     @field.bindings = {object: @object}


### PR DESCRIPTION
Based on this: http://rspec.info/blog/2014/05/notable-changes-in-rspec-3,
I updated 2 rspec specs to use the new syntax to remove these warnings.
```
WARNING: "Using `stub` from rspec-mocks' old `:should` syntax 
without explicitly enabling the syntax is deprecated. Use the new 
`:expect` syntax or explicitly enable `:should` instead.
```