### PR TITLE
Remove safe_yaml.

### DIFF
--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -9,6 +9,7 @@ require 'rails_admin/extensions/paper_trail'
 require 'rails_admin/extensions/history'
 require 'rails_admin/support/csv_converter'
 require 'rails_admin/support/hash_helper'
+require 'yaml'
 
 module RailsAdmin
   # Setup RailsAdmin
@@ -32,6 +33,28 @@ module RailsAdmin
     else
       RailsAdmin::Config
     end
+  end
+
+  # Backwards-compatible with safe_yaml/load when SafeYAML isn't available.
+  # Evaluates available YAML loaders at boot and creates appropriate method,
+  # so no conditionals are required at runtime.
+  begin
+    require 'safe_yaml/load'
+    def self.yaml_load(yaml)
+      SafeYAML.load(yaml)
+    end
+  rescue LoadError
+    if YAML.respond_to?(:safe_load)
+      def self.yaml_load(yaml)
+        YAML.safe_load(yaml)
+      end
+    else
+      raise LoadError.new "Safe-loading of YAML is not available. Please install 'safe_yaml' or install Psych 2.0+"
+    end
+  end
+
+  def self.yaml_dump(object)
+    YAML.dump(object)
   end
 end
 

--- a/lib/rails_admin/config/fields/types/serialized.rb
+++ b/lib/rails_admin/config/fields/types/serialized.rb
@@ -9,11 +9,11 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option :formatted_value do
-            YAML.dump(value) unless value.nil?
+            RailsAdmin.yaml_dump(value) unless value.nil?
           end
 
           def parse_value(value)
-            value.present? ? (SafeYAML.load(value) || nil) : nil
+            value.present? ? (RailsAdmin.yaml_load(value) || nil) : nil
           end
 
           def parse_input(params)

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -7,7 +7,6 @@ require 'rack-pjax'
 require 'rails'
 require 'rails_admin'
 require 'remotipart'
-require 'safe_yaml/load'
 
 module RailsAdmin
   class Engine < Rails::Engine

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-pjax', '~> 0.7'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']
   spec.add_dependency 'remotipart', '~> 1.0'
-  spec.add_dependency 'safe_yaml', '~> 1.0'
   spec.add_dependency 'sass-rails', ['>= 4.0', '< 6']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ['Erik Michaels-Ober', 'Bogdan Gaza', 'Petteri Kaapa', 'Benoit Benezech', 'Mitsuhiro Shibuya']

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -50,11 +50,11 @@ describe RailsAdmin::AbstractModel do
       end
 
       it 'lists elements within outbound limits' do
-        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 02, 2012 00:00', 'January 03, 2012 00:00'], o: 'between'}}}).count).to eq(2)
-        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 02, 2012 00:00', 'January 02, 2012 00:00'], o: 'between'}}}).count).to eq(1)
-        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 03, 2012 00:00', ''], o: 'between'}}}).count).to eq(2)
-        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', '', 'January 02, 2012 00:00'], o: 'between'}}}).count).to eq(2)
-        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['January 02, 2012 00:00'], o: 'default'}}}).count).to eq(1)
+        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 02, 2012 12:00', 'January 03, 2012 12:00'], o: 'between'}}}).count).to eq(2)
+        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 02, 2012 12:00', 'January 02, 2012 12:00'], o: 'between'}}}).count).to eq(1)
+        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', 'January 03, 2012 12:00', ''], o: 'between'}}}).count).to eq(2)
+        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['', '', 'January 02, 2012 12:00'], o: 'between'}}}).count).to eq(2)
+        expect(@abstract_model.all(filters: {'datetime_field' => {'1' => {v: ['January 02, 2012 12:00'], o: 'default'}}}).count).to eq(1)
       end
     end
   end

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -315,10 +315,10 @@ describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
 
     it 'supports datetime type query' do
       scope = FieldTest.all
-      expect(abstract_model.send(:filter_scope, scope,  'datetime_field' => {'1' => {v: ['', 'February 01, 2012 00:00', 'March 01, 2012 00:00'], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field BETWEEN ? AND ?)', Time.local(2012, 2, 1), Time.local(2012, 3, 1).end_of_day]).where_values)
-      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['', 'March 01, 2012 00:00', ''], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field >= ?)', Time.local(2012, 3, 1)]).where_values)
-      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['', '', 'February 01, 2012 00:00'], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field <= ?)', Time.local(2012, 2, 1).end_of_day]).where_values)
-      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['February 01, 2012 00:00'], o: 'default'}}).where_values).to eq(scope.where(['(field_tests.datetime_field BETWEEN ? AND ?)', Time.local(2012, 2, 1), Time.local(2012, 2, 1).end_of_day]).where_values)
+      expect(abstract_model.send(:filter_scope, scope,  'datetime_field' => {'1' => {v: ['', 'February 01, 2012 12:00', 'March 01, 2012 12:00'], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field BETWEEN ? AND ?)', Time.local(2012, 2, 1), Time.local(2012, 3, 1).end_of_day]).where_values)
+      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['', 'March 01, 2012 12:00', ''], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field >= ?)', Time.local(2012, 3, 1)]).where_values)
+      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['', '', 'February 01, 2012 12:00'], o: 'between'}}).where_values).to eq(scope.where(['(field_tests.datetime_field <= ?)', Time.local(2012, 2, 1).end_of_day]).where_values)
+      expect(abstract_model.send(:filter_scope, scope, 'datetime_field' => {'1' => {v: ['February 01, 2012 12:00'], o: 'default'}}).where_values).to eq(scope.where(['(field_tests.datetime_field BETWEEN ? AND ?)', Time.local(2012, 2, 1), Time.local(2012, 2, 1).end_of_day]).where_values)
     end
 
     it 'supports enum type query' do


### PR DESCRIPTION
I don't think it's really this gem's job, but besides that, I was getting a failure
when starting zeus, so I just made it optional.

The below stacktrace is from a fork of v0.6.7 with a commit on top of it:

https://github.com/swipesense/rails_admin/commits/0.6.7-eager_loading

Here's the stacktrace:

```plain
$ zeus rake

     ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:33:in `<class:Parser>': superclass mismatch for class Mark (TypeError)
from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:32:in `<module:Psych>'
from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:1:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych.rb:7:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/psych_handler.rb:1:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:130:in `<module:SafeYAML>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:26:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml.rb:1:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/bundler/gems/rails_admin-975bb5075824/lib/rails_admin/engine.rb:10:in `<top (required)>'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `block in require'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:240:in `load_dependency'
from ~/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/dependencies.rb:274:in `require'
from ~/projects/rails_server/bundle/ruby/2.2.0/bundler/gems/rails_admin-975bb5075824/lib/rails_admin.rb:1:in `<top (required)>'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `require'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `each'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `block in require'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `each'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `require'
from ~/.rvm/gems/ruby-2.2.2/gems/bundler-1.10.6/lib/bundler.rb:134:in `require'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus/rails.rb:97:in `default_bundle'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:200:in `run_action'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:74:in `block (2 levels) in boot_steps'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus/load_tracking.rb:7:in `features_loaded_by'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:73:in `block in boot_steps'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:56:in `catch'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:56:in `boot_steps'
from ~/.rvm/gems/ruby-2.2.2/gems/zeus-0.15.4/lib/zeus.rb:48:in `go'
from -e:1:in `<main>'
```