### PR TITLE
Improve efficiency of filter query in Postgres

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -211,7 +211,12 @@ module RailsAdmin
               return
             end
           end
-          ["(LOWER(#{@column}) #{like_operator} ?)", @value]
+
+          if ar_adapter == 'postgresql'
+            ["(#{@column} ILIKE ?)", @value]
+          else
+            ["(LOWER(#{@column}) LIKE ?)", @value]
+          end
         end
 
         def build_statement_for_enum
@@ -221,10 +226,6 @@ module RailsAdmin
 
         def ar_adapter
           ::ActiveRecord::Base.connection.adapter_name.downcase
-        end
-
-        def like_operator
-          ar_adapter == 'postgresql' ? 'ILIKE' : 'LIKE'
         end
       end
     end


### PR DESCRIPTION
In Postgres, filter queries currently generate a condition `LOWER(field) ILIKE ?`. This defeats the benefit of using ILIKE, which is case insensitive, and also prevents an index from being used. This fixes the issue by changing the condition to `field ILIKE ?` in Postgres.