### PR TITLE
Don't ignore RailsAdmin controllers in NewRelic

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -11,8 +11,6 @@ module RailsAdmin
   end
 
   class ApplicationController < Config.parent_controller.constantize
-    newrelic_ignore if defined?(NewRelic)
-
     before_filter :_authenticate!
     before_filter :_authorize!
     before_filter :_audit!


### PR DESCRIPTION
Closes https://github.com/sferik/rails_admin/issues/2318

First introduced in https://github.com/sferik/rails_admin/commit/33917af63de8ec166b3e6456c5af0a3da90a49df, the linked commit unilaterally removes the ability to measure RailsAdmin performance with NewRelic. This is a crazy thing to do out of the box, and incredibly surprising to find.

NewRelic offers many robust ways for users to ignore endpoints that they choose, from the method used here to https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ignoring-specific-transactions. There's no reason for RailsAdmin to be this prescriptive about this topic.

Personally, I am concerned about RailsAdmin performance in production, and want some insight into why our admin console times out so frequently.