### PR TITLE
Import custom variables before Bootstrap variables.

### DIFF
--- a/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
+++ b/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
@@ -35,10 +35,10 @@
 
 /***  Variables  ***/
 
+@import "rails_admin/custom/variables";
 @import "rails_admin/bootstrap/variables";
 @import "rails_admin/base/variables";
 @import "rails_admin/themes/<%= theme %>/variables";
-@import "rails_admin/custom/variables";
 
 /***  Mixins  ***/
 


### PR DESCRIPTION
Take advantage of the Sass !default flag in order to configure Bootstrap.