### PR TITLE
Changing a field's type shouldn't position it at the bottom

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -21,11 +21,11 @@ module RailsAdmin
         elsif type && type != (field.nil? ? nil : field.type)
           if field
             properties = field.properties
-            _fields.delete(field)
+            field = _fields[_fields.index(field)] = RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)
           else
             properties = abstract_model.properties.detect { |p| name == p.name }
+            field = (_fields << RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)).last
           end
-          field = (_fields << RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)).last
         end
 
         # If field has not been yet defined add some default properties

--- a/spec/rails_admin/config/has_fields_spec.rb
+++ b/spec/rails_admin/config/has_fields_spec.rb
@@ -35,4 +35,20 @@ describe RailsAdmin::Config::HasFields do
     end
     expect(RailsAdmin.config(Team).fields.detect { |f| f.name == :players }.properties).not_to be_nil
   end
+
+  it 'does not change the order of existing fields, if some field types of them are changed' do
+    original_fields_order = RailsAdmin.config(Team).fields.map(&:name)
+
+    RailsAdmin.config do |config|
+      config.model Team do
+        configure :players, :enum do
+          enum { [] }
+        end
+
+        configure :revenue, :integer
+      end
+    end
+
+    expect(RailsAdmin.config(Team).fields.map(&:name)).to eql(original_fields_order)
+  end
 end


### PR DESCRIPTION
Fields that have been re-configured with different types should remain at the original positions, not append at the end of the fields list

For example, I have a couple fields in the middle of my form, :state and :state_updated_at as a pair of related fields. :state has a type as :string by default, but I would like to make it as :enum. Configuring the :state field will separate two fields and make :state appear at the bottom. 

🙏🙏🙏