### PR TITLE
Fix error with paperclip

### DIFF
--- a/lib/rails_admin/config/fields/factories/paperclip.rb
+++ b/lib/rails_admin/config/fields/factories/paperclip.rb
@@ -5,7 +5,7 @@ require 'rails_admin/config/fields/types/file_upload'
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
   extensions = [:file_name, :content_type, :file_size, :updated_at, :fingerprint]
   model = parent.abstract_model.model
-  if (properties.name.to_s =~ /^(.+)_file_name$/) && defined?(::Paperclip) && model.attachment_definitions && model.attachment_definitions.key?(attachment_name = Regexp.last_match[1].to_sym)
+  if (properties.name.to_s =~ /^(.+)_file_name$/) && defined?(::Paperclip) && model.try(:attachment_definitions) && model.attachment_definitions.key?(attachment_name = Regexp.last_match[1].to_sym)
     field = RailsAdmin::Config::Fields::Types.load(:paperclip).new(parent, attachment_name, properties)
     children_fields = []
     extensions.each do |ext|


### PR DESCRIPTION
Fix for http://stackoverflow.com/questions/17523849/rails-4-paperclip-and-rails-admin-undefined-method-attachment-definitions-er

Paperclip factory tries to register paperclip type even when there is no `has_attached_file` definition in the model. That causes `undefined method 'attachment_definitions'` erorr.