### PR TITLE
Remove the field on "nested:fieldRemoved"

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
+++ b/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
@@ -50,3 +50,4 @@ $(document).on 'nested:fieldRemoved', 'form', (content) ->
     add_button = toggler.next()
     add_button.addClass('add_nested_fields').html(add_button.data('add-label'))
 
+  field.remove()


### PR DESCRIPTION
* to avoid useless error on save when removed nested fields have some
  HTML5 validation errors