### PR TITLE
Show sidebar scrollbar only on demand.

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -335,7 +335,7 @@ body.rails_admin {
       position: fixed;
       top: $navbar-height;
       bottom: 0;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
   }
 }


### PR DESCRIPTION
Avoid permanent visible scrollbar in sidebar by setting `overflow-y` to `auto` instead of `scroll`.