### PR TITLE
fixes #2420 : ckeditor integration and relative_url_root option

### DIFF
--- a/lib/rails_admin/config/fields/types/ck_editor.rb
+++ b/lib/rails_admin/config/fields/types/ck_editor.rb
@@ -21,7 +21,7 @@ module RailsAdmin
 
           # Use this if you want to point to a cloud instances of the base CKeditor
           register_instance_option :base_location do
-            "#{Rails.application.config.assets.prefix}/ckeditor/"
+            [Rails.application.config.relative_url_root, Rails.application.config.assets.prefix, 'ckeditor/'].compact.join('/')
           end
 
           register_instance_option :partial do


### PR DESCRIPTION
The ck_editor field ignored Rails.config.relative_url_root option, thus instances of RA deployed under a subdir would not have working CKEditor instances