### PR TITLE
Added spec for datetime field

### DIFF
--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -83,7 +83,7 @@ module RailsAdmin
         return if delocalized_value.blank?
 
         begin
-          ::DateTime.strptime(delocalized_value, strftime_format)
+          Time.zone.local_to_utc(::DateTime.strptime(delocalized_value, strftime_format))
         rescue ArgumentError
           nil
         end

--- a/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
@@ -127,4 +127,29 @@ describe 'RailsAdmin Basic Edit', type: :request do
       expect(page.current_url).to eq('http://www.example.com/admin/ball?sort=color')
     end
   end
+
+  describe 'clicking save without changing anything' do
+    before { @datetime = 'October 08, 2015 06:45' }
+    context 'when config.time_zone set' do
+      before do
+        allow(Time).to receive(:zone){  ActiveSupport::TimeZone.new('Central Time (US & Canada)') } # tantamount to setting config.time_zone = 'Central Time (US & Canada)'
+      end
+      it 'does not alter datetime fields' do
+        visit new_path(model_name: 'field_test')
+        find('#field_test_datetime_field').set(@datetime)
+        click_button 'Save and edit'
+        expect(find('#field_test_datetime_field').value).to eq(@datetime)
+      end
+    end
+
+    context 'without config.time_zone set (default)' do
+      it 'does not alter datetime fields' do
+        visit new_path(model_name: 'field_test')
+        find('#field_test_datetime_field').set(@datetime)
+        click_button 'Save and edit'
+        expect(find('#field_test_datetime_field').value).to eq(@datetime)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Rails 4.2.3
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]
OSX 10.11

It seems after v0.6.8 that when a custom Rails config.time_zone is used and you save a datetime field without altering it, RailsAdmin appears to mutate the value of the field. I'm not certain why this is happening. It does appear to work correctly when config.time_zone is not set.