### PR TITLE
Fix: Pundit adapter blindly ignores existing pundit_user definition

### DIFF
--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -8,7 +8,10 @@ module RailsAdmin
         # See the +authorize_with+ config method for where the initialization happens.
         def initialize(controller)
           @controller = controller
-          @controller.class.send(:alias_method, :pundit_user, :_current_user)
+
+          unless @controller.respond_to? :pundit_user
+            @controller.class.send(:alias_method, :pundit_user, :_current_user)
+          end
         end
 
         # This method is called in every controller action and should raise an exception
@@ -52,7 +55,7 @@ module RailsAdmin
         def policy(record)
           @controller.policy(record)
         rescue ::Pundit::NotDefinedError
-          ::ApplicationPolicy.new(@controller.send(:_current_user), record)
+          ::ApplicationPolicy.new(@controller.send(:pundit_user), record)
         end
       end
     end


### PR DESCRIPTION
As per the pundit readme, there are instances where I need to provide additional context about the user. I do this by defining pundit_user, however the pundit rails_admin adapter ignores this and replaces it with it's own pointing at current_user. This breaks policies that rely on the additional context.

This patch addresses this.

In addition to this I have another issue with the pundit adapter, and I'd like to include some fixes for it as well, but before just doing them I'd like to see if there's a good reason why things have been done the way they are.

Typically the method name for checking with pundit for "can I do X" will be suffixed with a "?". Currently the pundit adapter does not do this.

I see 2 problems with this:
1. In scenario #1, it means aliasing a bunch of methods (i.e. `alias_method :index, :index?`) - a minor incovenience
2. In scenario #2, I may want different permissions for rails_admin than my standard application policies, for some reason. Currently I'm able to do this because it calls different methods (those without a question mark), but it's not particularly clear that these are specifically for rails_admin. This has confused a junior developer here already.

I'd like to put a patch together that basically either prefixes the methods with rails_admin, or works more like [sudosu/rails_admin_pundit](https://github.com/sudosu/rails_admin_pundit) where it runs through a specific method, which in turn can use a case statement.

I'd appreciate any input on that before I write a patch and start depending on it.