### PR TITLE
Fallback to default locale instead of :en

### DIFF
--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -38,7 +38,7 @@ module RailsAdmin
           end
 
           register_instance_option :strftime_format do
-            fallback = ::I18n.t(date_format, scope: i18n_scope, locale: :en)
+            fallback = ::I18n.t(date_format, scope: i18n_scope, locale: ::I18n.default_locale)
             ::I18n.t(date_format, scope: i18n_scope, default: fallback).to_s
           end
 

--- a/spec/rails_admin/config/fields/types/datetime_spec.rb
+++ b/spec/rails_admin/config/fields/types/datetime_spec.rb
@@ -25,6 +25,34 @@ describe RailsAdmin::Config::Fields::Types::Datetime do
 
       expect(field.formatted_value).to eq 'January 01, 2012 00:00'
     end
+
+    it 'handles non-English applications' do
+      begin
+        old_available_locales = I18n.available_locales
+        old_default_locale = I18n.default_locale
+        old_locale = I18n.locale
+
+        I18n.available_locales = [:fr]
+        I18n.default_locale = :fr
+        I18n.locale = :fr
+
+        RailsAdmin.config(FieldTest) do |_config|
+          field :datetime_field do
+            default_value DateTime.parse('01/01/2012')
+          end
+        end
+
+        field = RailsAdmin.config(FieldTest).fields.detect do |f|
+          f.name == :datetime_field
+        end.with(object: FieldTest.new)
+
+        expect(field.formatted_value).to eq 'dimanche 01 janvier 2012 00:00'
+      ensure
+        I18n.available_locales = old_available_locales
+        I18n.default_locale = old_default_locale
+        I18n.locale = old_locale
+      end
+    end
   end
 
   describe '#parse_input' do


### PR DESCRIPTION
Fix #2432

