### PR TITLE
Little fix for nested forms

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
+++ b/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
@@ -50,8 +50,6 @@ $(document).on 'nested:fieldRemoved', 'form', (content) ->
     add_button = toggler.next()
     add_button.addClass('add_nested_fields').html(add_button.data('add-label'))
 
-  # Removing all reuired attributes from deleted child form to bypass browser validations.
+  # Removing all required attributes from deleted child form to bypass browser validations.
   field.find('[required]').each ->
-    #console.log $(this).attr('name')
     $(this).removeAttr('required')
-    return

--- a/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
+++ b/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
@@ -50,3 +50,8 @@ $(document).on 'nested:fieldRemoved', 'form', (content) ->
     add_button = toggler.next()
     add_button.addClass('add_nested_fields').html(add_button.data('add-label'))
 
+  # Removing all reuired attributes from deleted child form to bypass browser validations.
+  field.find('[required]').each ->
+    #console.log $(this).attr('name')
+    $(this).removeAttr('required')
+    return


### PR DESCRIPTION
According to this issue: #2443, removed nested child objects still go through validations.

This little fix makes browser ignore validaitons of removed nested child models.

Tested using Mongoid.