### PR TITLE
Limit children for deletion notice

### DIFF
--- a/app/views/rails_admin/main/_delete_notice.html.haml
+++ b/app/views/rails_admin/main/_delete_notice.html.haml
@@ -8,12 +8,17 @@
   - else
     = wording
   %ul
-    - @abstract_model.each_associated_children(object) do |association, child|
-      %li
-        - child_config = RailsAdmin.config(child)
-        = @abstract_model.model.human_attribute_name association.name
-        - wording = child.send(child_config.object_label_method)
-        - if child.id && (show_action = action(:show, child_config.abstract_model, child))
-          = link_to(wording, url_for(action: show_action.action_name, model_name: child_config.abstract_model.to_param, id: child.id), class: 'pjax')
-        - else
-          = wording
+    - @abstract_model.each_associated_children(object) do |association, children|
+      - humanized_association = @abstract_model.model.human_attribute_name association.name
+      - limit = children.count > 12 ? 10 : children.count
+      - children.first(limit).each do |child|
+        = content_tag_for :li, child do
+          - child_config = RailsAdmin.config(child)
+          = humanized_association.singularize
+          - wording = child.send(child_config.object_label_method)
+          - if child.id && (show_action = action(:show, child_config.abstract_model, child))
+            = link_to(wording, url_for(action: show_action.action_name, model_name: child_config.abstract_model.to_param, id: child.id), class: 'pjax')
+          - else
+            = wording
+      - if children.count > limit
+        %li= t('admin.misc.more', count: children.count - limit, models_name: humanized_association)

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -44,6 +44,7 @@ en:
       navigation_static_label: "Links"
       log_out: "Log out"
       ago: "ago"
+      more: "Plus %{count} more %{models_name}"
     flash:
       successful: "%{name} successfully %{action}"
       error: "%{name} failed to be %{action}"

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -91,7 +91,7 @@ module RailsAdmin
           end
         when :has_many
           children = object.send(association.name)
-          yield(association, children)
+          yield(association, Array.new(children))
         end
       end
     end

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -87,12 +87,11 @@ module RailsAdmin
         case association.type
         when :has_one
           if child = object.send(association.name)
-            yield(association, child)
+            yield(association, [child])
           end
         when :has_many
-          object.send(association.name).each do |child| # rubocop:disable ShadowingOuterLocalVariable
-            yield(association, child)
-          end
+          children = object.send(association.name)
+          yield(association, children)
         end
       end
     end

--- a/spec/integration/basic/delete/rails_admin_basic_delete_spec.rb
+++ b/spec/integration/basic/delete/rails_admin_basic_delete_spec.rb
@@ -60,4 +60,17 @@ describe 'RailsAdmin Basic Delete', type: :request do
       is_expected.to have_link(@player.name, href: "/admin/player/#{@player.id}")
     end
   end
+
+  describe 'delete an object which has many associated item' do
+    before do
+      comments = FactoryGirl.create_list :comment, 20
+      @player = FactoryGirl.create :player, comments: comments
+      visit delete_path(model_name: 'player', id: @player.id)
+    end
+
+    it 'shows only ten first plus x mores', skip_mongoid: true do
+      is_expected.to have_selector('.comment', count: 10)
+      is_expected.to have_content('Plus 10 more Comments')
+    end
+  end
 end

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -75,4 +75,24 @@ describe RailsAdmin::AbstractModel do
       @abstract_model.all(sort: PK_COLUMN, page: 1, per: 2)
     end
   end
+
+  describe 'each_associated_children' do
+    before do
+      @abstract_model = RailsAdmin::AbstractModel.new('Player')
+      @draft = FactoryGirl.build :draft
+      @comments = FactoryGirl.build_list :comment, 2
+      @player = FactoryGirl.build :player, draft: @draft, comments: @comments
+    end
+
+    it 'should return has_one and has_many associations with its children' do
+      @abstract_model.each_associated_children(@player) do |association, children|
+        expect(children).to eq case association.name
+                               when :draft
+                                 [@draft]
+                               when :comments
+                                 @comments
+                               end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Limit number of future orphans displayed during deletion confirmation in order to avoid performance issue.