### PR TITLE
json.rb now rescues JSON::ParserError

### DIFF
--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -14,7 +14,11 @@ module RailsAdmin
           end
 
           def parse_value(value)
-            value.present? ? JSON.parse(value) : nil
+            begin
+              value.present? ? JSON.parse(value) : nil
+            rescue JSON::ParserError
+              nil
+            end
           end
 
           def parse_input(params)

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -17,8 +17,8 @@ describe RailsAdmin::Config::Fields::Types::Json do
       expect(field.parse_input(json_field: data.to_json)).to eq data
     end
 
-    it 'raise JSON::ParserError with invalid json string' do
-      expect { field.parse_input(json_field: '{{') }.to raise_error(JSON::ParserError)
+    it 'returns nil with invalid json string' do
+      expect { field.parse_input(json_field: '{{') }.to be_nil
     end
   end
 


### PR DESCRIPTION
Fixing the bug raised in this issue:
crash on querying models with json columns
https://github.com/sferik/rails_admin/issues/2502