### PR TITLE
Added ability to change models number limit manually.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/MethodLength:
   Max: 29 # TODO: Lower to 15
 
 Metrics/ModuleLength:
-  Max: 164 # TODO: Lower to 100
+  Max: 166 # TODO: Lower to 100
 
 Metrics/ParameterLists:
   Max: 8 # TODO: Lower to 4

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -72,6 +72,9 @@ module RailsAdmin
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
 
+      # This method will set limit of models that will be uploaded in association fields
+      attr_accessor :association_select_models_number_limit
+
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #
@@ -278,6 +281,7 @@ module RailsAdmin
         @navigation_static_links = {}
         @navigation_static_label = nil
         @parent_controller = '::ApplicationController'
+        @association_select_models_number_limit = 100
         RailsAdmin::Config::Actions.reset
       end
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -71,10 +71,8 @@ module RailsAdmin
 
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
-
       # This method will set limit of models that will be uploaded in association fields
       attr_accessor :association_select_models_number_limit
-
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -71,8 +71,10 @@ module RailsAdmin
 
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
+
       # This method will set limit of models that will be uploaded in association fields
       attr_accessor :association_select_models_number_limit
+
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -54,7 +54,7 @@ module RailsAdmin
         # preload entire associated collection (per associated_collection_scope) on load
         # Be sure to set limit in associated_collection_scope if set is large
         register_instance_option :associated_collection_cache_all do
-          @associated_collection_cache_all ||= (associated_model_config.abstract_model.count < 100)
+          @associated_collection_cache_all ||= (associated_model_config.abstract_model.count < RailsAdmin::Config.association_select_models_number_limit)
         end
 
         # determines whether association's elements can be removed


### PR DESCRIPTION
According to #1369 RailAdmin set number of models that will be uploaded to multiselect forms. In other cases it will load nothing, forcing user to write something on input field to make search.

This feature makes users to be able to set number of limit manually:

     RailsAdmin.config do |config|
          config.association_select_models_number_limit = 500
     end