### PR TITLE
Allow `.parent` method to exist on models

### DIFF
--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -85,9 +85,8 @@ module RailsAdmin
         @navigation_label ||= begin
           # Use source method object in case it's overwritten in the model
           parent_module = Class.method(:parent).unbind.bind(abstract_model.model).call
-          if parent_module != Object
-            parent_module.to_s
-          end
+
+          parent_module.to_s if parent_module != Object
         end
       end
 

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -83,7 +83,9 @@ module RailsAdmin
 
       register_instance_option :navigation_label do
         @navigation_label ||= begin
-          if (parent_module = abstract_model.model.parent) != Object
+          # Use source method object in case it's overwritten in the model
+          parent_module = Class.method(:parent).unbind.bind(abstract_model.model).call
+          if parent_module != Object
             parent_module.to_s
           end
         end

--- a/spec/dummy_app/app/active_record/player.rb
+++ b/spec/dummy_app/app/active_record/player.rb
@@ -21,4 +21,11 @@ class Player < ActiveRecord::Base
   def draft_id=(id)
     self.draft = Draft.find_by_id(id)
   end
+
+  # This method doesn't do anything other that make sure that a
+  # particular bug fails the test suite if exposed
+  # See: https://github.com/sferik/rails_admin/pull/2512
+  def self.parent
+    nil
+  end
 end


### PR DESCRIPTION
If you define a `parent` method on your model then this line becomes a problem.  We can get the original method and bind it to our model like this.  Perhaps a bit klugey.  I'm open to other suggestions
