### PR TITLE
Add SVG file extension to the image detection method

### DIFF
--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -42,7 +42,7 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            (url = resource_url.to_s) && url.split('.').last =~ /jpg|jpeg|png|gif/i
+            (url = resource_url.to_s) && url.split('.').last =~ /jpg|jpeg|png|gif|svg/i
           end
 
           register_instance_option :allowed_methods do


### PR DESCRIPTION
Detect SVG file uploads as images and present them properly on the interface.