### PR TITLE
Fix for bug: Uncaught Error: Syntax error

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
+++ b/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
@@ -29,7 +29,7 @@ $(document).on 'nested:fieldAdded', 'form', (content) ->
 $(document).on 'nested:fieldRemoved', 'form', (content) ->
   field = content.field
   nav = field.closest(".control-group").children('.controls').children('.nav')
-  current_li = nav.children('li').has('a[href=#' + field.attr('id') + ']')
+  current_li = nav.children('li').has('a[href="#' + field.attr('id') + '"]')
   parent_group = field.closest(".control-group")
   controls = parent_group.children('.controls')
   one_to_one = controls.data('nestedone') != undefined


### PR DESCRIPTION
Fix for bug:
Uncaught Error: Syntax error, unrecognized expression: a[href=#unique-id- XXXXXXXXXXXXX ]
When it tries to remove a new nested entity.