### PR TITLE
Fix momentjs translations for '%-d' format day of the month

### DIFF
--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -10,6 +10,7 @@ module RailsAdmin
         '%b' => 'MMM',        # The abbreviated month name ("Jan")
         '%B' => 'MMMM',       # The  full  month  name ("January")
         '%d' => 'DD',         # Day of the month (01..31)
+        '%-d' => 'D',         # Day of the month (1..31)
         '%D' => 'MM/DD/YY',   # American date format mm/dd/yy
         '%e' => 'D',          # Day of the month (1..31)
         '%F' => 'YY-MM-DD',   # ISO 8601 date format

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -8,6 +8,7 @@ describe RailsAdmin::Support::Datetime do
       '%D de %M de %Y, %H:%M:%S' => 'MM/DD/YY [de] mm [de] YYYY, HH:mm:ss',
       '%d/%-m/%Y, %H:%M:%S' => 'DD/M/YYYY, HH:mm:ss',
       '%d de %B de %Y' => 'DD [de] MMMM [de] YYYY',
+      '%-d %B %Y' => 'D MMMM YYYY',
     }.each do |strftime_format, momentjs_format|
       it "convert strftime_format to momentjs_format - example #{strftime_format}" do
         strftime_format = RailsAdmin::Support::Datetime.new(strftime_format)


### PR DESCRIPTION
Russian date long format has '%-d', so to_momentjs method translate "%-d %B %Y" into " MMMM YYYY"

https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ru.yml#L43