### PR TITLE
Fix delocalize strftime_format for DateTime.strptime to support minus

### DIFF
--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -89,7 +89,7 @@ module RailsAdmin
 
         begin
           # Adjust with the correct timezone and daylight savint time
-          datetime_with_wrong_tz = ::DateTime.strptime(delocalized_value, strftime_format)
+          datetime_with_wrong_tz = ::DateTime.strptime(delocalized_value, strftime_format.gsub('%-d', '%d'))
           Time.zone.parse(datetime_with_wrong_tz.strftime('%Y-%m-%d %H:%M:%S'))
         rescue ArgumentError
           nil

--- a/spec/rails_admin/config/fields/types/datetime_spec.rb
+++ b/spec/rails_admin/config/fields/types/datetime_spec.rb
@@ -39,9 +39,9 @@ describe RailsAdmin::Config::Fields::Types::Datetime do
       Time.zone = 'UTC'
     end
 
-    it 'is able to read %B %d, %Y %H:%M' do
+    it 'is able to read %B %-d, %Y %H:%M' do
       @object = FactoryGirl.create(:field_test)
-      @object.datetime_field = field.parse_input(datetime_field: @time.strftime('%B %d, %Y %H:%M'))
+      @object.datetime_field = field.parse_input(datetime_field: @time.strftime('%B %-d, %Y %H:%M'))
       expect(@object.datetime_field.strftime('%Y-%m-%d %H:%M')).to eq(@time.strftime('%Y-%m-%d %H:%M'))
     end
 


### PR DESCRIPTION
DateTime.strprime can't parse formats that have '%-d' (https://github.com/svenfuchs/rails-i18n/search?utf8=%E2%9C%93&q=%25-d). So parse_string method returns nil and date field isn't saved correctly. I guess most users just overwrite date format to make rails_admin works properly, but this small fix let rails_admin works out of the box.