### PR TITLE
Not paginating when showing all history

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -106,7 +106,7 @@
     - if @objects.respond_to?(:total_count)
       - total_count = @objects.total_count.to_i
       .row
-        .col-md-6= paginate(@objects, theme: 'twitter-bootstrap', remote: true)
+        .col-md-6= paginate(@objects, theme: 'twitter-bootstrap', remote: true) unless params[:all]
       .row
         .col-md-6= link_to(t("admin.misc.show_all"), index_path(params.merge(all: true)), class: "show-all btn btn-default clearfix pjax") unless total_count > 100 || total_count <= @objects.to_a.size
       .clearfix.total-count= "#{total_count} #{@model_config.pluralize(total_count).downcase}"

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -106,7 +106,7 @@
     - if @objects.respond_to?(:total_count)
       - total_count = @objects.total_count.to_i
       .row
-        .col-md-6= paginate(@objects, theme: 'twitter-bootstrap', remote: true) unless params[:all]
+        .col-md-6= paginate(@objects, theme: 'twitter-bootstrap', remote: true)
       .row
         .col-md-6= link_to(t("admin.misc.show_all"), index_path(params.merge(all: true)), class: "show-all btn btn-default clearfix pjax") unless total_count > 100 || total_count <= @objects.to_a.size
       .clearfix.total-count= "#{total_count} #{@model_config.pluralize(total_count).downcase}"

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -97,7 +97,7 @@ module RailsAdmin
           versions = versions.where('event LIKE ?', "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == 'true' ? "#{sort} DESC" : sort)
           versions = all ? versions : versions.send(Kaminari.config.page_method_name, current_page).per(per_page)
-          paginated_proxies = Kaminari.paginate_array([], total_count: versions.total_count)
+          paginated_proxies = Kaminari.paginate_array([], total_count: versions.try(:total_count) || versions.count)
           paginated_proxies = paginated_proxies.page(current_page).per(per_page)
           versions.each do |version|
             paginated_proxies << VersionProxy.new(version, @user_class)

--- a/spec/integration/history/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/history/rails_admin_paper_trail_spec.rb
@@ -48,6 +48,12 @@ describe 'RailsAdmin PaperTrail history', active_record: true do
         expect(versions.next_page).to eq(3)
       end
 
+      it 'can fetch all history' do
+        versions = @adapter.listing_for_model @model, nil, false, false, true, nil, 20
+        expect(versions.total_count).to eq(30)
+        expect(versions.count).to eq(30)
+      end
+
       describe 'returned version objects' do
         before(:each) do
           @padinated_listing = @adapter.listing_for_model @model, nil, false, false, false, nil


### PR DESCRIPTION
When showing all history, we don't use paging (we're showing all history after all). But since Kaminari only adds extension methods when paging is used, so we end up in a situation where the paging methods are missing (which we assume are there). This happens when we're showing all history

Related issue:
https://github.com/sferik/rails_admin/issues/2503