### PR TITLE
Support translation for active record enum type

### DIFF
--- a/lib/rails_admin/config/fields/types/active_record_enum.rb
+++ b/lib/rails_admin/config/fields/types/active_record_enum.rb
@@ -12,11 +12,11 @@ module RailsAdmin
           end
 
           register_instance_option :enum do
-            abstract_model.model.defined_enums[name.to_s]
+            Hash[defined_enums.map{|k, v| [i18n_method(k), v]}]
           end
 
           register_instance_option :pretty_value do
-            bindings[:object].send(name).presence || ' - '
+            i18n_name || bindings[:object].send(name).presence || ' - '
           end
 
           register_instance_option :multiple? do
@@ -28,11 +28,25 @@ module RailsAdmin
           end
 
           def parse_value(value)
-            value.present? ? enum.invert[value.to_i] : nil
+            value.present? ? defined_enums.invert[value.to_i] : nil
           end
 
           def parse_input(params)
             params[name] = parse_value(params[name]) if params[name]
+          end
+
+          def defined_enums
+            abstract_model.model.defined_enums[name.to_s]
+          end
+
+          def i18n_method(method)
+            _path = "enums.#{abstract_model.model.model_name.i18n_key.to_s}.#{name}.#{method}"
+            I18n.exists?(_path) ? I18n.t(_path) : method
+          end
+
+          def i18n_name
+            _path = "enums.#{abstract_model.model.model_name.i18n_key.to_s}.#{name}.#{bindings[:object].send(name)}"
+            I18n.exists?(_path) ? I18n.t(_path) : nil
           end
         end
       end


### PR DESCRIPTION
How about support translations for ActiveRecord enum?

Example:

```
en:
  enums:
    model_name:
       enum_field_name:
          enabled: Enabled
          disabled: Disabled
          ...

```
