### PR TITLE
Explicity call the #t method on I18n

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -75,7 +75,7 @@ module RailsAdmin
     end
 
     def redirect_to_on_success
-      notice = t('admin.flash.successful', name: @model_config.label, action: t("admin.actions.#{@action.key}.done"))
+      notice = I18n.t('admin.flash.successful', name: @model_config.label, action: I18n.t("admin.actions.#{@action.key}.done"))
       if params[:_add_another]
         redirect_to new_path(return_to: params[:return_to]), flash: {success: notice}
       elsif params[:_add_edit]
@@ -105,7 +105,7 @@ module RailsAdmin
     end
 
     def handle_save_error(whereto = :new)
-      flash.now[:error] = t('admin.flash.error', name: @model_config.label, action: t("admin.actions.#{@action.key}.done").html_safe).html_safe
+      flash.now[:error] = I18n.t('admin.flash.error', name: @model_config.label, action: I18n.t("admin.actions.#{@action.key}.done").html_safe).html_safe
       flash.now[:error] += %(<br>- #{@object.errors.full_messages.join('<br>- ')}).html_safe
 
       respond_to do |format|
@@ -116,7 +116,7 @@ module RailsAdmin
 
     def check_for_cancel
       return unless params[:_continue] || (params[:bulk_action] && !params[:bulk_ids])
-      redirect_to(back_or_index, notice: t('admin.flash.noaction'))
+      redirect_to(back_or_index, notice: I18n.t('admin.flash.noaction'))
     end
 
     def get_collection(model_config, scope, pagination)


### PR DESCRIPTION
I'm building an API using `rails-api` and I had the same issue as described in #2293, so I added `require: false` to my Gemfile and explicitly called `require 'rails-api'` in my `ApplicationController`. 
When I then saved an record from with in rails admin I got an error `undefined method 't' for #<RailsAdmin::MainController:0x007f99a7bbc978>`. 
The fix is _very_ simple as you can see :)

thanks for an awesome gem! :star: 