### PR TITLE
Making Gravatar optional in config

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -37,7 +37,7 @@ module RailsAdmin
       return nil unless (edit_action = RailsAdmin::Config::Actions.find(:edit, controller: controller, abstract_model: abstract_model, object: _current_user)).try(:authorized?)
       link_to url_for(action: edit_action.action_name, model_name: abstract_model.to_param, id: _current_user.id, controller: 'rails_admin/main') do
         html = []
-        html << image_tag("#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", alt: '') if _current_user.email.present?
+        html << image_tag("#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", alt: '') if RailsAdmin::Config.show_gravatar && _current_user.email.present?
         html << content_tag(:span, _current_user.email)
         html.join.html_safe
       end

--- a/lib/generators/rails_admin/templates/initializer.erb
+++ b/lib/generators/rails_admin/templates/initializer.erb
@@ -19,6 +19,10 @@ RailsAdmin.config do |config|
 
   ### More at https://github.com/sferik/rails_admin/wiki/Base-configuration
 
+  ## == Gravatar integration ==
+  ## To disable Gravatar integration in Navigation Bar set to false
+  # config.show_gravatar true
+
   config.actions do
     dashboard                     # mandatory
     index                         # mandatory

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -68,6 +68,9 @@ module RailsAdmin
       # @see RailsAdmin.config
       attr_reader :registry
 
+      # show Gravatar in Navigation bar
+      attr_accessor :show_gravatar
+
       # accepts a hash of static links to be shown below the main navigation
       attr_accessor :navigation_static_links
       attr_accessor :navigation_static_label
@@ -279,6 +282,7 @@ module RailsAdmin
         @label_methods = [:name, :title]
         @main_app_name = proc { [Rails.application.engine_name.titleize.chomp(' Application'), 'Admin'] }
         @registry = {}
+        @show_gravatar = true
         @navigation_static_links = {}
         @navigation_static_label = nil
         @parent_controller = '::ApplicationController'

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -391,7 +391,6 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
         allow(helper).to receive(:_current_user).and_return(FactoryGirl.create(:user))
         result = helper.edit_user_link
         expect(result).not_to include('gravatar')
-
       end
     end
   end

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -385,7 +385,7 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
 
       it "don't show gravatar" do
         RailsAdmin.config do |config|
-          config.show_gravatar false
+          config.show_gravatar = false
         end
 
         allow(helper).to receive(:_current_user).and_return(FactoryGirl.create(:user))


### PR DESCRIPTION
Added ability to disable Gravatar via config. Because including of the gravatar has moved from _secondary_navigation.html.haml to application_helper.rb disabling of the Gravatar icon in the Navbar has become very uncomfortable. So I have added config.show_gravatar which allows disabling the Gravatar via config.
#1073