### PR TITLE
Fixes #2575 (pundit asking for all rows from models by monkey patching pundit

### DIFF
--- a/config/initializers/pundit_patch.rb
+++ b/config/initializers/pundit_patch.rb
@@ -1,0 +1,20 @@
+# This file adds a method to the Pundit module that is logically
+# equivalent to Pundit#policy_scope, except when there is no
+# policy scope, nil is returned instead of raising a
+# Pundit::NotDefinedError.
+#
+# In addition to allowing us to avoid using exceptions as
+# flow-control, this bypasses any time consuming things that may occur
+# when the exception is created.
+#
+# In specific, this avoids sending inspect to an
+# ActiveRecord::Relation, which can be an exceedingly expensive
+# operation if that relation, for example, describes over a million
+# rows.
+if defined?(Pundit)
+  module Pundit
+    def policy_scope_or_nil(scope)
+      policy_scopes[scope] ||= Pundit.policy_scope(pundit_user, scope)
+    end
+  end
+end

--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -33,9 +33,8 @@ module RailsAdmin
         # and bulk_delete/destroy actions and should return a scope which limits the records
         # to those which the user can perform the given action on.
         def query(_action, abstract_model)
-          @controller.policy_scope(abstract_model.model.all)
-        rescue ::Pundit::NotDefinedError
-          abstract_model.model.all
+          @controller.policy_scope_or_nil(abstract_model.model.all) ||
+            abstract_model.model.all
         end
 
         # This is called in the new/create actions to determine the initial attributes for new

--- a/spec/integration/authorization/pundit_spec.rb
+++ b/spec/integration/authorization/pundit_spec.rb
@@ -107,6 +107,21 @@ describe 'RailsAdmin Pundit Authorization', type: :request do
       is_expected.not_to have_content('Add new')
     end
 
+    context do
+      let(:uninspectable_all) do
+        Player.all.tap do |all|
+          def all.inspect
+            fail 'All was inspected; this can be costly.'
+          end
+        end
+      end
+
+      it 'GET /admin should not call Player.all.inspect' do
+        allow(Player).to receive(:all).and_return(uninspectable_all)
+        visit dashboard_path
+      end
+    end
+
     it 'GET /admin/team should raise Pundit::NotAuthorizedError' do
       expect { visit index_path(model_name: 'team') }.to raise_error(Pundit::NotAuthorizedError)
     end


### PR DESCRIPTION
I'm not super happy with this PR, in that patching pundit seems ugly in general and adding a method whose name ends with `_or_nil` is gross in specific. However, the problem in the issue is real and this PR does resolve the problem.

I looked at pundit and didn't see a method that RailsAdmin could use to avoid the problem. Perhaps it makes sense to also submit a PR to pundit or at least open up an issue. Additionally, it's not obvious to me that having `ActiveRecord::Relation#inspect` retrieve all the rows of the relation is a particularly good idea, either.

So, I'm not at all wedded to this particular solution, but I am hoping that the issue is addressed so we can go back to using a stock RailsAdmin without monkey-patching.
