### PR TITLE
Fix associations search with new objects

### DIFF
--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -19,7 +19,14 @@ module RailsAdmin
       end
 
       def get(id)
-        AbstractObject.new(model.find(id))
+        object = model.find(id)
+
+        if object.present?
+          AbstractObject.new(object)
+        else
+          self.new
+        end
+
       rescue => e
         raise e if %w(
           Mongoid::Errors::DocumentNotFound


### PR DESCRIPTION
When you are trying to search objects at the has_many search box, it gives undefined associations error with new objects. It just returns a new abstract object or a found abstract object.