### PR TITLE
Add instance option to append a CSS class for rows

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -90,7 +90,7 @@
           %th.last.shrink
       %tbody
         - @objects.each do |object|
-          %tr{class: "#{@abstract_model.param_key}_row"}
+          %tr{class: "#{@abstract_model.param_key}_row #{@model_config.list.with(object: object).row_css_class}"}
             %td
               = check_box_tag "bulk_ids[]", object.id, false
             - if @other_left_link ||= other_left && index_path(params.except('set').merge(params[:set].to_i != 1 ? {set: (params[:set].to_i - 1)} : {}))

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -25,6 +25,10 @@ module RailsAdmin
         register_instance_option :scopes do
           []
         end
+
+        register_instance_option :row_css_class do
+          ''
+        end
       end
     end
   end


### PR DESCRIPTION
As Rails Admin uses Bootstrap, I wanted to use the table's contextual classes in my lists.
This is an approach to implement that using a method declared in RailsAdmin::Config, it has access to the object being rendered into the row.
### Usage

``` ruby
RailsAdmin.config do |config|
config.model Event do
  list do
    row_css_class do
      bindings[:object].mode == 'panic' ? 'danger' : 'success'
    end
end
```
