### PR TITLE
Duplicate filters on history nav

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -3,6 +3,10 @@
   var filters;
 
   $.filters = filters = {
+    container: function() {
+      return $('#filters_box');
+    },
+
     append: function(options) {
       options = options || {};
       var field_label = options['label'];
@@ -104,7 +108,7 @@
         .append('<span class="label label-info form-label"><a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw icon-white"></i>' + field_label + '</a></span>')
         .append('&nbsp;' + control + '&nbsp;' + (additional_control || ''));
 
-      $('#filters_box').append($content);
+      filters.container().append($content);
 
       $content.find('.date, .datetime').datetimepicker({
         locale: RailsAdmin.I18n.locale,
@@ -113,6 +117,14 @@
       });
 
       $("hr.filters_box:hidden").show('slow');
+    },
+
+    init: function(filterOptionSets) {
+      if(filters.container().html().length == 0){
+        for( var i = 0; i < filterOptionSets.length; i++ ){
+          filters.append(filterOptionSets[i]);
+        }
+      }
     }
   }
 

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -57,7 +57,7 @@ module RailsAdmin
     end
 
     def ordered_filter_string
-      @ordered_filter_string ||= ordered_filters.map do |duplet|
+      @ordered_filter_string ||= %{$.filters.init([#{ordered_filters.map do |duplet|
         options = {index: duplet[0]}
         filter_for_field = duplet[1]
         filter_name = filter_for_field.keys.first
@@ -77,8 +77,8 @@ module RailsAdmin
         options[:value] = filter_hash['v']
         options[:label] = field.label
         options[:operator] = filter_hash['o']
-        %{$.filters.append(#{options.to_json});}
-      end.join("\n").html_safe if ordered_filters
+        options.to_json
+      end.join(", ")}]);}.html_safe if ordered_filters
     end
   end
 end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -276,7 +276,7 @@ describe 'RailsAdmin Basic List', type: :request do
       end
       get index_path(model_name: 'player')
 
-      options = {
+      options1 = {
         index: 1,
         label: 'Name',
         name: 'name',
@@ -284,9 +284,8 @@ describe 'RailsAdmin Basic List', type: :request do
         value: '',
         operator: nil,
       }
-      expect(response.body).to include("$.filters.append(#{options.to_json});")
 
-      options = {
+      options2 = {
         index: 2,
         label: 'Team',
         name: 'team',
@@ -294,7 +293,7 @@ describe 'RailsAdmin Basic List', type: :request do
         value: '',
         operator: nil,
       }
-      expect(response.body).to include("$.filters.append(#{options.to_json});")
+      expect(response.body).to include("$.filters.init([#{options1.to_json}, #{options2.to_json}]);")
     end
   end
 


### PR DESCRIPTION
There is a bug in which index page filters are duplicated when navigating back or forward in browser history. It's not a total show-stopper, but it's been bothering some of my users. And it is obviously incorrect/buggy behavior.

Repro steps:
1) Navigate to a RailsAdmin resource index.
2) Filter the index by some criteria (ex: 'Created At' => 'Is present')
3) Click "refresh" to apply the filter
4) Navigate somewhere within RailsAdmin (ex: click to "edit" a record in the index)
5) Navigate "back" via your browsers back button to the index.

Notice that there are now two "Created At" filters. Navigate forward and back again, now there are three... yikes!

This is because when navigating back the previously rendered filters are still on the page, but the inline script to `append` new filters gets run again.

The fix that I've come up with is to create an alternative function, `$.filters.init`, which is called inline instead. `init` simply checks whether any filters have been rendered already, and only builds filters for the array of options it is passed if they have not.

I've updated specs that test the view helper construction of the inline script. However, I found no tests anywhere that cover the behavior of `$.filters`, so I did not add tests for `$.filters.init`.
