### PR TITLE
Add support for grouping list by associated model

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -240,20 +240,20 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
         options = $(@).data('options')
         config_options = $.parseJSON(options['config_options'])
         if config_options
-          if !config_options['inlineMode']
-            config_options['inlineMode'] = false
+          config_options['imageUploadParams'].authenticity_token = $('meta[name=csrf-token]').attr('content');
+          config_options['imageManagerLoadParams'].authenticity_token = $('meta[name=csrf-token]').attr('content');
+          if !config_options['toolbarInline']
+            config_options['toolbarInline'] = false
         else
-          config_options = { inlineMode: false }
+          config_options = {toolbarInline: false}
 
-        uploadEnabled =
         if config_options['imageUploadURL']
-          config_options['imageUploadParams'] =
-            authenticity_token: $('meta[name=csrf-token]').attr('content')
+          uploadEnabled = true;
 
         $(@).addClass('froala-wysiwyged')
-        $(@).editable(config_options)
+        $(@).froalaEditor(config_options)
         if uploadEnabled
-          $(@).on 'editable.imageError', (e, editor, error) ->
+          $(@).on 'froalaEditor.imageError', (e, editor, error) ->
             alert("error uploading image: " + error.message);
             # Custom error message returned from the server.
             if error.code == 0
@@ -283,7 +283,7 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
 
             return
 
-          .on('editable.afterRemoveImage', (e, editor, $img) ->
+          .on('froalaEditor.image.removed', (e, editor, $img) ->
             # Set the image source to the image delete params.
             editor.options.imageDeleteParams =
               src: $img.attr('src')
@@ -291,16 +291,16 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
             # Make the delete request.
             editor.deleteImage $img
             return
-          ).on('editable.imageDeleteSuccess', (e, editor, data) ->
+          ).on('froalaEditor.imageDeleteSuccess', (e, editor, data) ->
             # handle success
-          ).on 'editable.imageDeleteError', (e, editor, error) ->
+          ).on 'froalaEditor.imageDeleteError', (e, editor, error) ->
             # handle error
             alert("error deleting image: " + error.message);
 
     array = content.find('[data-richtext=froala-wysiwyg]').not('.froala-wysiwyged')
     if array.length
       options = $(array[0]).data('options')
-      if not $.isFunction($.fn.editable)
+      if not $.isFunction($.fn.froalaEditor)
         $('head').append('<link href="' + options['csspath'] + '" rel="stylesheet" media="all" type="text\/css">')
         $.getScript options['jspath'], (script, textStatus, jqXHR) =>
           goFroalaWysiwygs(array)

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -66,6 +66,12 @@
         %li{class: "#{'active' if scope.to_s == params[:scope] || (params[:scope].blank? && index == 0)}"}
           %a{href: index_path(params.merge(scope: scope, page: nil)), class: 'pjax'}= I18n.t("admin.scopes.#{@abstract_model.to_param}.#{scope}", default: I18n.t("admin.scopes.#{scope}", default: scope.to_s.titleize))
 
+  - unless @model_config.list.group_by.nil?
+    %ul.nav.nav-tabs#group_selector
+      - @groups.each_with_index do |group, index|
+        %li{class: "#{'active' if group.send(@group_primary_key).to_s == params[:group_id] || (params[:group_id].blank? && index == 0)}"}
+          %a{href: index_path(params.merge(group_id: group.send(@group_primary_key), page: nil)), class: 'pjax'}= I18n.t("admin.groups.#{@abstract_model.to_param}.#{group.send(@group_model_config.object_label_method)}", default: I18n.t("admin.groups.#{group.send(@group_model_config.object_label_method)}", default: group.send(@group_model_config.object_label_method).titleize))
+
   = form_tag bulk_action_path(model_name: @abstract_model.to_param), method: :post, id: "bulk_form", class: "form" do
     = hidden_field_tag :bulk_action
     - if description.present?

--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -39,6 +39,15 @@ module RailsAdmin
               end
             end
 
+            unless @model_config.list.group_by.nil?
+              @group_model_config = RailsAdmin.config(@model_config.list.group_by[:model])
+              @group_primary_key = @group_model_config.abstract_model.primary_key
+              @groups = list_entries(@group_model_config, :index, nil, nil)
+              group_id = params[:group_id].blank? ? @groups.first.try(@group_primary_key) : params[:group_id]
+
+              @objects = @objects.where(@model_config.list.group_by[:key] => group_id)
+            end
+
             respond_to do |format|
               format.html do
                 render @action.template_name, status: (flash[:error].present? ? :not_found : 200)

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -25,6 +25,10 @@ module RailsAdmin
         register_instance_option :scopes do
           []
         end
+
+        register_instance_option :group_by do
+          nil
+        end
       end
     end
   end

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'font-awesome-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'haml', '~> 4.0'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
-  spec.add_dependency 'jquery-ui-rails', '~> 5.0'
+  spec.add_dependency 'jquery-ui-rails', '~> 6.0'
   spec.add_dependency 'kaminari', '~> 0.14'
   spec.add_dependency 'nested_form', '~> 0.3'
   spec.add_dependency 'rack-pjax', '~> 0.7'


### PR DESCRIPTION
There is no docs and tests. Also there is place for improvements. But currently I just want to ask if this option is useful. I use it to group my products by stores using same tabs as for scopes. Current usage:

``` ruby
class Product < ApplicationRecord
  belongs_to :store
end

class Store < ApplicationRecord
  has_many :producs
end

model.config Product do
  list do
    group_by { key: :store_id, model: Store }
  end
end
```

So if it's useful i will add docs/tests and do some refactoring. Suggestions are welcome.

P.S. Froala v2 update included :)
