### PR TITLE
Ensure parameters is actually a Hash.

### DIFF
--- a/lib/rails_admin/config/actions/new.rb
+++ b/lib/rails_admin/config/actions/new.rb
@@ -20,7 +20,7 @@ module RailsAdmin
               @authorization_adapter && @authorization_adapter.attributes_for(:new, @abstract_model).each do |name, value|
                 @object.send("#{name}=", value)
               end
-              if object_params = params[@abstract_model.to_param]
+              if (object_params = params[@abstract_model.to_param]).is_a?(Hash)
                 @object.set_attributes(@object.attributes.merge(object_params))
               end
               respond_to do |format|


### PR DESCRIPTION
If you have a model named `Action` or a model that answer `action` to `#to_param` message, it causes a crash when trying to parse controller params as it explained #2329.

Proposed solution is an attempt to fix that issue. 