### PR TITLE
Loosen requirements for rack-pjax to support rack 2.0/rails 5

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -59,7 +59,6 @@ appraise "rails-5.0" do
   gem 'rails', '~> 5.0.0.rc1'
   gem 'sass-rails', '~> 5.0'
   gem 'devise', '~> 4.0'
-  gem 'rack-pjax', github: 'afcapel/rack-pjax'
   gem 'remotipart', github: 'mshibuya/remotipart'
 
   group :test do

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -6,7 +6,6 @@ gem "appraisal", ">= 2.0"
 gem "devise", "~> 4.0"
 gem "rails", "~> 5.0.0.rc1"
 gem "sass-rails", "~> 5.0"
-gem "rack-pjax", :github => "afcapel/rack-pjax"
 gem "remotipart", :github => "mshibuya/remotipart"
 
 group :active_record do

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
   spec.add_dependency 'kaminari', '~> 0.14'
   spec.add_dependency 'nested_form', '~> 0.3'
-  spec.add_dependency 'rack-pjax', '~> 0.7'
+  spec.add_dependency 'rack-pjax', '>= 0.7'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']
   spec.add_dependency 'remotipart', '~> 1.0'
   spec.add_dependency 'safe_yaml', '~> 1.0'


### PR DESCRIPTION
rack-pjax 1.0 has been released and it works with rack 2.0.