### PR TITLE
added pundit policy authorized

### DIFF
--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -17,6 +17,7 @@ module RailsAdmin
         # instance if it is available.
         def authorize(action, abstract_model = nil, model_object = nil)
           record = model_object || abstract_model && abstract_model.model
+          @controller.instance_variable_set(:@_pundit_policy_authorized, true)
           fail ::Pundit::NotAuthorizedError.new("not allowed to #{action} this #{record}") unless policy(record).send(action_for_pundit(action)) if action
         end
 


### PR DESCRIPTION
Pundit allows you to check if the authorize method was called for every page. Raises an error if it isn't. Rails Admin currently fails at it because it doesn't set the @_pundit_policy_authorized variable. This is just a quick fix. (taking inspiration from the rails_admin_pundit gem)