### PR TITLE
Surface collection association getter for ease of overloading

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module RailsAdmin
   class MainController < RailsAdmin::ApplicationController
     include ActionView::Helpers::TextHelper
@@ -120,7 +121,7 @@ module RailsAdmin
     end
 
     def get_collection(model_config, scope, pagination)
-      associations = model_config.list.fields.select { |f| f.type == :belongs_to_association && !f.polymorphic? }.collect { |f| f.association.name }
+      associations = get_associations_for_collection(model_config)
       options = {}
       options = options.merge(page: (params[Kaminari.config.param_name] || 1).to_i, per: (params[:per] || model_config.list.items_per_page)) if pagination
       options = options.merge(include: associations) unless associations.blank?
@@ -129,6 +130,10 @@ module RailsAdmin
       options = options.merge(filters: params[:f]) if params[:f].present?
       options = options.merge(bulk_ids: params[:bulk_ids]) if params[:bulk_ids]
       model_config.abstract_model.all(options, scope)
+    end
+
+    def get_associations_for_collection(model_config)
+      model_config.list.fields.select { |f| f.type == :belongs_to_association && !f.polymorphic? }.collect { |f| f.association.name }
     end
 
     def get_association_scope_from_params
@@ -142,3 +147,4 @@ module RailsAdmin
     end
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
e.g. it allows someone to [eager load has_one and has_many
associations](https://github.com/sferik/rails_admin/pull/2441)
without requiring a change in RailsAdmin:

```diff
     def get_associations_for_collection(model_config)
-      model_config.list.fields.select { |f| f.type == :belongs_to_association                                                  && !f.polymorphic? }.collect { |f| f.association.name }
+      model_config.list.fields.select { |f| f.type.in?([:belongs_to_association, :has_one_association, :has_many_association]) && !f.polymorphic? }.collect { |f| f.association.name }
     end
```