### PR TITLE
Update rack-pjax to 1.0 to resolve Rack dependency with Rails 5

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
   spec.add_dependency 'kaminari', '~> 0.14'
   spec.add_dependency 'nested_form', '~> 0.3'
-  spec.add_dependency 'rack-pjax', '~> 0.7'
+  spec.add_dependency 'rack-pjax', '~> 1.0'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']
   spec.add_dependency 'remotipart', '~> 1.0'
   spec.add_dependency 'safe_yaml', '~> 1.0'


### PR DESCRIPTION
This is a fix for #2619 