### PR TITLE
bugfix: form_value use enum value not the key in active_record

### DIFF
--- a/lib/rails_admin/config/fields/types/active_record_enum.rb
+++ b/lib/rails_admin/config/fields/types/active_record_enum.rb
@@ -34,6 +34,14 @@ module RailsAdmin
           def parse_input(params)
             params[name] = parse_value(params[name]) if params[name]
           end
+
+          def form_default_value
+            enum[super]
+          end
+
+          def form_value
+            enum[super]
+          end
         end
       end
     end


### PR DESCRIPTION
when i use enum feature in my active record, the value of the select in form is '' because the value option of the select is enum's value not the key.
eg: there is a Product model with enum  status:  {spare: 1, on_sale: 2, off_sale: 3}
without this commit, 
![image](https://cloud.githubusercontent.com/assets/2297117/16289870/7c5b2eb2-392b-11e6-8ace-23168acb9540.png) the status field is always null, because rails_admin form builder can't find the correct value for the select
with this commit,
![image](https://cloud.githubusercontent.com/assets/2297117/16289890/b4dcd18c-392b-11e6-9e4a-f8550f4ce856.png)
it will find the correct value, so the select value will be filled correctly

