### PR TITLE
Include url helpers to ApplicationHelper

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -3,6 +3,7 @@ require 'rails_admin/support/i18n'
 module RailsAdmin
   module ApplicationHelper
     include RailsAdmin::Support::I18n
+    include RailsAdmin::Engine.routes.url_helpers
 
     def capitalize_first_letter(wording)
       return nil unless wording.present? && wording.is_a?(String)


### PR DESCRIPTION
I was getting no route matches error after upgrading to rails 5.0.0.rc2. This commit fixes the bug by including url_helpers to `ApplicationHelper` 

See: https://github.com/sferik/rails_admin/issues/2662