### PR TITLE
Add viewport meta tag to mobile layout adjustment

### DIFF
--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{content: "IE=edge", "http-equiv" => "X-UA-Compatible"}
     %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}
+    %meta{content: "width=device-width, initial-scale=1", name: "viewport; charset=utf-8"}
     %meta{content: "NONE,NOARCHIVE", name: "robots"}
     = csrf_meta_tag
     = stylesheet_link_tag "rails_admin/rails_admin.css", media: :all


### PR DESCRIPTION
When using a smartphone, the layout do not adjust automatically, even with themes custom css because of the abscence of the viewport meta tag.