### PR TITLE
Fix missing associated_model_config exception

### DIFF
--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -56,7 +56,7 @@ module RailsAdmin
     end
 
     def export_fields_for(method, model_config = @model_config)
-      model_config.export.fields.select { |f| f.name == method }
+      model_config.export.fields.select { |f| f.name == method.to_sym }
     end
 
     def generate_csv_string(options)


### PR DESCRIPTION
Hey!

CSV export did not work for me for `rails 5.0.rc2` release. Tracing that down i found that it was caused by type inconsistent ( comparing string vs symbol )

Please see attached screenshot.

![](https://2.downloader.disk.yandex.ru/preview/7667f437c2458b2b170fdfce2bfc1d772a0274af1b59268ded7b5b63b214ff16/inf/UGjATmKV7KahukEnDct5x90iYlgtinoI1cNLWNb_XAVRGGjgwXF2yObZDPruXrRCZIz2-BRUZEmrWvq5taytJg%3D%3D?uid=0&filename=2016-06-27_15-17-26.png&disposition=inline&hash=&limit=0&content_type=image%2Fpng&tknv=v2&size=XXL&crop=0)