### PR TITLE
Ensure dashboard/statistics is being fully tested

### DIFF
--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -18,16 +18,19 @@ describe RailsAdmin::MainController, type: :controller do
     end
 
     it 'shows statistics by default' do
-      expect(RailsAdmin.config(Player).abstract_model).to receive(:count).and_return(0)
+      allow(RailsAdmin.config(Player).abstract_model).to receive(:count).and_return(0)
+      expect(RailsAdmin.config(Player).abstract_model).to receive(:count)
       controller.dashboard
     end
 
     it 'does not show statistics if turned off' do
       RailsAdmin.config do |c|
+        c.included_models = [Player]
         c.actions do
           dashboard do
             statistics false
           end
+          index # mandatory
         end
       end
 


### PR DESCRIPTION
  * Currently we are not checking if the statistics are really showing up.
  And since we are not adding the `index` action to the config block -
  which is mandatory - they actually will never appear, therefore the
  test will always pass, making the `statistics` flag useless.

  * Add an extra test to ensure we have both scenarios of showing or
  hiding statistics.