### PR TITLE
Support for ActiveRecord:Enum using string columns

### DIFF
--- a/lib/rails_admin/config/fields/types/active_record_enum.rb
+++ b/lib/rails_admin/config/fields/types/active_record_enum.rb
@@ -28,7 +28,7 @@ module RailsAdmin
           end
 
           def parse_value(value)
-            value.present? ? enum.invert[value.to_i] : nil
+            value.present? ? enum.invert[type_cast_value(value)] : nil
           end
 
           def parse_input(params)
@@ -37,6 +37,18 @@ module RailsAdmin
 
           def form_value
             ::Rails.version >= '5' ? enum[super] : super
+          end
+
+        private
+
+          def type_cast_value(value)
+            if ::Rails.version >= '5'
+              abstract_model.model.attribute_types[name].cast(value)
+            elsif ::Rails.version >= '4.2'
+              abstract_model.model.column_types[name].type_cast_from_user(value)
+            else
+              abstract_model.model.column_types[name.to_s].type_cast(value)
+            end
           end
         end
       end

--- a/spec/dummy_app/app/active_record/player.rb
+++ b/spec/dummy_app/app/active_record/player.rb
@@ -10,6 +10,10 @@ class Player < ActiveRecord::Base
     record.errors.add(:base, 'Player is cheating') if value.to_s =~ /on steroids/
   end
 
+  if ::Rails.version >= '4.1'
+    enum formation: {start: 'start', substitute: 'substitute'}
+  end
+
   before_destroy :destroy_hook
 
   def destroy_hook; end

--- a/spec/dummy_app/app/active_record/team.rb
+++ b/spec/dummy_app/app/active_record/team.rb
@@ -14,6 +14,10 @@ class Team < ActiveRecord::Base
   validates_numericality_of :revenue, allow_nil: true
   belongs_to :division
 
+  if ::Rails.version >= '4.1'
+    enum main_sponsor: [:no_sponsor, :food_factory, :transportation_company, :bank, :energy_producer]
+  end
+
   def player_names_truncated
     players.collect(&:name).join(', ')[0..32]
   end

--- a/spec/dummy_app/app/locales/models.en.yml
+++ b/spec/dummy_app/app/locales/models.en.yml
@@ -5,6 +5,7 @@ en:
         name: Their Name
       team:
         manager: Team Manager
+        main_sponsor: Main Sponsor
         fans: Some Fans
   mongoid:
     *en_attributes

--- a/spec/dummy_app/app/mongoid/player.rb
+++ b/spec/dummy_app/app/mongoid/player.rb
@@ -13,6 +13,7 @@ class Player
   field :born_on, type: Date
   field :notes, type: String
   field :suspended, type: Boolean, default: false
+  field :formation, type: String
 
   validates_presence_of(:name)
   validates_numericality_of(:number, only_integer: true)

--- a/spec/dummy_app/app/mongoid/team.rb
+++ b/spec/dummy_app/app/mongoid/team.rb
@@ -17,6 +17,7 @@ class Team
   field :revenue, type: BigDecimal
   field :color, type: String
   field :custom_field, type: String
+  field :main_sponsor, type: Integer
 
   has_many :players, inverse_of: :team, order: :_id.asc
   has_and_belongs_to_many :fans

--- a/spec/dummy_app/db/migrate/20160728152942_add_main_sponsor_to_teams.rb
+++ b/spec/dummy_app/db/migrate/20160728152942_add_main_sponsor_to_teams.rb
@@ -1,0 +1,5 @@
+class AddMainSponsorToTeams < MigrationBase
+  def change
+    add_column :teams, :main_sponsor, :integer, default: 0, null: false
+  end
+end

--- a/spec/dummy_app/db/migrate/20160728153058_add_formation_to_players.rb
+++ b/spec/dummy_app/db/migrate/20160728153058_add_formation_to_players.rb
@@ -1,0 +1,5 @@
+class AddFormationToPlayers < MigrationBase
+  def change
+    add_column :players, :formation, :string, default: 'substitute', null: false
+  end
+end

--- a/spec/integration/basic/export/rails_admin_basic_export_spec.rb
+++ b/spec/integration/basic/export/rails_admin_basic_export_spec.rb
@@ -46,10 +46,10 @@ describe 'RailsAdmin Export', type: :request do
       click_button 'Export to csv'
       csv = CSV.parse page.driver.response.body.force_encoding('utf-8') # comes through as us-ascii on some platforms
       expect(csv[0]).to match_array ['Id', 'Created at', 'Updated at', 'Deleted at', 'Name', 'Position',
-                                     'Number', 'Retired', 'Injured', 'Born on', 'Notes', 'Suspended', 'Id [Team]', 'Created at [Team]',
+                                     'Number', 'Retired', 'Injured', 'Born on', 'Notes', 'Suspended', 'Formation', 'Id [Team]', 'Created at [Team]',
                                      'Updated at [Team]', 'Name [Team]', 'Logo url [Team]', 'Team Manager [Team]', 'Ballpark [Team]',
                                      'Mascot [Team]', 'Founded [Team]', 'Wins [Team]', 'Losses [Team]', 'Win percentage [Team]',
-                                     'Revenue [Team]', 'Color [Team]', 'Custom field [Team]', 'Id [Draft]', 'Created at [Draft]',
+                                     'Revenue [Team]', 'Color [Team]', 'Custom field [Team]', 'Main Sponsor [Team]', 'Id [Draft]', 'Created at [Draft]',
                                      'Updated at [Draft]', 'Date [Draft]', 'Round [Draft]', 'Pick [Draft]', 'Overall [Draft]',
                                      'College [Draft]', 'Notes [Draft]', 'Id [Comments]', 'Content [Comments]', 'Created at [Comments]',
                                      'Updated at [Comments]']

--- a/spec/rails_admin/config/sections_spec.rb
+++ b/spec/rails_admin/config/sections_spec.rb
@@ -114,8 +114,8 @@ describe RailsAdmin::Config::Sections do
       expect(RailsAdmin.config(Team).edit.visible_groups.collect { |g| g.visible_fields.collect(&:name) }).to eq([[:name], [:founded, :wins]])
       expect(RailsAdmin.config(Team).create.visible_groups.collect { |g| g.visible_fields.collect(&:name) }).to eq([[:name], [:founded, :wins]])
       expect(RailsAdmin.config(Team).update.visible_groups.collect { |g| g.visible_fields.collect(&:name) }).to eq([[:name], [:founded], [:wins], [:losses]])
-      expect(RailsAdmin.config(Team).visible_groups.collect { |g| g.visible_fields.collect(&:name) }.flatten.count).to eq(19)
-      expect(RailsAdmin.config(Team).export.visible_groups.collect { |g| g.visible_fields.collect(&:name) }.flatten.count).to eq(19)
+      expect(RailsAdmin.config(Team).visible_groups.collect { |g| g.visible_fields.collect(&:name) }.flatten.count).to eq(20)
+      expect(RailsAdmin.config(Team).export.visible_groups.collect { |g| g.visible_fields.collect(&:name) }.flatten.count).to eq(20)
     end
   end
 end


### PR DESCRIPTION
ActiveRecord::Enum supports storing values in string database columns. This behaviour is not yet described in the rails documentation, but recently a test case for it was added. (https://github.com/rails/rails/commit/67c1719012506c3387df067961252b5df50a97ce)

I did not add extra tests for it, since the active_record_enum Type has not been tested previously. I did however add ActiveRecord::Enum attributes (with and without string columns) to the test models, so the behaviour is at least tested implicitly.