### PR TITLE
Added option list to disable link "Add filter"

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -37,7 +37,7 @@ module RailsAdmin
     end
 
     def filterable_fields
-      @filterable_fields ||= @model_config.list.fields.select(&:filterable?)
+      @filterable_fields ||= @model_config.list.fields.select(&:filterable?) if @model_config.add_filter
     end
 
     def ordered_filters

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -97,6 +97,10 @@ module RailsAdmin
         nil
       end
 
+      register_instance_option :add_filter do
+        true
+      end
+
       # Act as a proxy for the base section configuration that actually
       # store the configurations.
       def method_missing(m, *args, &block)

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -296,6 +296,33 @@ describe 'RailsAdmin Basic List', type: :request do
       }
       expect(response.body).to include("$.filters.append(#{options.to_json});")
     end
+
+    it 'not displays option "Add filter" when option filterable_fields is false' do
+      RailsAdmin.config Player do
+        add_filter false
+      end
+      get index_path(model_name: 'player')
+
+      expect(response.body).not_to include("Add filter")
+    end
+
+    it 'displays option "Add filter" when option filterable_fields is true' do
+      RailsAdmin.config Player do
+        add_filter true
+      end
+      get index_path(model_name: 'player')
+
+      expect(response.body).to include("Add filter")
+    end
+
+    it 'displays option "Add filter" when option filterable_fields not present' do
+      RailsAdmin.config Player do
+        add_filter true
+      end
+      get index_path(model_name: 'player')
+      
+      expect(response.body).to include("Add filter")
+    end
   end
 
   describe 'GET /admin/player with 2 objects' do


### PR DESCRIPTION
I added an option to disable the link "Add filter" if the developer does not wish the option is visible desired model.

Without the option, or to set it to true, the option will appear normally.
```ruby
config.model 'About' do
  list do
    field :id
    field :title
  end
end
```
or 

```ruby
config.model 'About' do
  add_filter true
  list do
    field :id
    field :title
  end
end
```
![screenshot from 2016-08-17 14-40-41](https://cloud.githubusercontent.com/assets/1373275/17748692/96184780-6488-11e6-8002-f6f860bdc797.png)

But, if set false, will not be show in the model list .

```ruby
config.model 'About' do
  add_filter false
  list do
    field :id
    field :title
  end
end
```

![screenshot from 2016-08-17 14-40-412](https://cloud.githubusercontent.com/assets/1373275/17748876/62917228-6489-11e6-8017-bd6756e234a4.png)

