### PR TITLE
pass parameters to new forms when model is namespaced

### DIFF
--- a/lib/rails_admin/config/actions/new.rb
+++ b/lib/rails_admin/config/actions/new.rb
@@ -20,7 +20,7 @@ module RailsAdmin
               @authorization_adapter && @authorization_adapter.attributes_for(:new, @abstract_model).each do |name, value|
                 @object.send("#{name}=", value)
               end
-              if object_params = params[@abstract_model.to_param]
+              if object_params = params[@abstract_model.param_key]
                 sanitize_params_for!(request.xhr? ? :modal : :create)
                 @object.set_attributes(@object.attributes.merge(object_params.to_h))
               end

--- a/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
+++ b/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
@@ -33,6 +33,5 @@ describe 'RailsAdmin Namespaced Model New', type: :request do
       visit new_path(model_name: 'cms~basic_page', cms_basic_page: {title: 'Hello'})
       expect(page).to have_css('input[value=Hello]')
     end
-
   end
 end

--- a/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
+++ b/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
@@ -27,4 +27,12 @@ describe 'RailsAdmin Namespaced Model New', type: :request do
       is_expected.to have_selector("textarea#cms_basic_page_content[name='cms_basic_page[content]']")
     end
   end
+
+  describe 'GET /admin/cms_basic_page/new with parameters for pre-population' do
+    it 'populates form field when corresponding parameters are passed in' do
+      visit new_path(model_name: 'cms~basic_page', cms_basic_page: {title: 'Hello'})
+      expect(page).to have_css('input[value=Hello]')
+    end
+
+  end
 end


### PR DESCRIPTION
When model is namespaced, the prepopulation of the new form via params didn't work.
That should fix it.
