### PR TITLE
Fixing test relations

### DIFF
--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -98,7 +98,7 @@ module RailsAdmin
 
         # Reader for the association's value unformatted
         def value
-          bindings[:object].send(association.name)
+          bindings[:object].public_send(association.name)
         end
 
         # has many?

--- a/spec/dummy_app/app/active_record/case.rb
+++ b/spec/dummy_app/app/active_record/case.rb
@@ -1,0 +1,3 @@
+class Case < ActiveRecord::Base
+  belongs_to :test, inverse_of: :cases
+end

--- a/spec/dummy_app/app/active_record/test.rb
+++ b/spec/dummy_app/app/active_record/test.rb
@@ -1,0 +1,3 @@
+class Test < ActiveRecord::Base
+  has_many :cases, inverse_of: :test
+end

--- a/spec/dummy_app/app/mongoid/case.rb
+++ b/spec/dummy_app/app/mongoid/case.rb
@@ -1,0 +1,8 @@
+class Case
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+
+  belongs_to :test
+end

--- a/spec/dummy_app/app/mongoid/test.rb
+++ b/spec/dummy_app/app/mongoid/test.rb
@@ -1,0 +1,8 @@
+class Test
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+
+  has_many :cases
+end

--- a/spec/dummy_app/db/migrate/20161013005520_create_tests.rb
+++ b/spec/dummy_app/db/migrate/20161013005520_create_tests.rb
@@ -5,4 +5,3 @@ class CreateTests < MigrationBase
     end
   end
 end
-

--- a/spec/dummy_app/db/migrate/20161013005520_create_tests.rb
+++ b/spec/dummy_app/db/migrate/20161013005520_create_tests.rb
@@ -1,0 +1,8 @@
+class CreateTests < MigrationBase
+  def change
+    create_table :tests do |t|
+      t.string :name
+    end
+  end
+end
+

--- a/spec/dummy_app/db/migrate/20161013005535_create_case.rb
+++ b/spec/dummy_app/db/migrate/20161013005535_create_case.rb
@@ -1,0 +1,9 @@
+class CreateCase < MigrationBase
+  def change
+    create_table :cases do |t|
+      t.string  :name
+      t.integer :test_id, null: false
+    end
+  end
+end
+

--- a/spec/dummy_app/db/migrate/20161013005535_create_case.rb
+++ b/spec/dummy_app/db/migrate/20161013005535_create_case.rb
@@ -6,4 +6,3 @@ class CreateCase < MigrationBase
     end
   end
 end
-

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -82,4 +82,12 @@ FactoryGirl.define do
   factory :paper_trail_test do
     sequence(:name) { |n| "name #{n}" }
   end
+
+  factory :test do
+    sequence(:name) { |n| "name #{n}" }
+  end
+
+  factory :case do
+    association :test
+  end
 end

--- a/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
@@ -75,9 +75,11 @@ describe 'RailsAdmin Basic Edit', type: :request do
 
     it 'shows associated objects' do
       is_expected.to have_selector '#fan_team_ids' do |select|
-        expect(select[0]).to have_selector 'option[selected="selected"]'
-        expect(select[1]).not_to have_selector 'option[selected="selected"]'
-        expect(select[2]).not_to have_selector 'option[selected="selected"]'
+        options = select.all 'option'
+
+        expect(options[0]['selected']).to eq 'selected'
+        expect(options[1]['selected']).to eq nil
+        expect(options[2]['selected']).to eq nil
       end
     end
   end

--- a/spec/integration/basic/show/rails_admin_basic_show_spec.rb
+++ b/spec/integration/basic/show/rails_admin_basic_show_spec.rb
@@ -79,4 +79,16 @@ describe 'RailsAdmin Basic Show', type: :request do
       is_expected.to have_css("a[href='/admin/player/#{@player.id}']")
     end
   end
+
+  describe 'show for object with test relation' do
+    before do
+      @test = FactoryGirl.create :test
+      @case = FactoryGirl.create :case, test: @test
+      visit show_path(model_name: 'case', id: @case.id)
+    end
+
+    it 'shows associated object' do
+      is_expected.to have_css("a[href='/admin/test/#{@test.id}']")
+    end
+  end
 end


### PR DESCRIPTION
When a model has a "test" relation, like the below example, navigating to the model's show page throws an `ArgumentError wrong number of arguments (0 for 2..3)` error. 
```
class Case < ActiveRecord::Base
  belongs_to :test, inverse_of: :cases
end
```
After digging around from what I can tell it's from the use of the `send` method in `lib/rails_admin/config/fields/association.rb`. 
The ActiveRecord::Base object appears to have a private `test` method that is being invoked before the public `test` method that retrieves the association. 

I've updated it to use `public_send` instead. I can't think of any reason where a private method would be used when retrieving the value for the association.