### PR TITLE
Association filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tmp/**/*
 .idea/*.xml
 .sass-cache
 nbproject
+/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tmp/**/*
 .sass-cache
 nbproject
 /.DS_Store
+*/**/.DS_Store

--- a/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
@@ -1,0 +1,43 @@
+(function (components) {
+
+  components.has_many_association_filter_component = function (options) {
+    var component = {};
+    if (options.check_boxes) {
+      var checked = function (value, applied_filters) {
+        return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
+      };
+      var new_checkbox = function (value) {
+        return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
+          '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
+          '' + value[0] +
+          '</label>';
+      };
+      component.control = options.checkbox_values.map(function (value) {
+        return new_checkbox(value)
+      }).join('\n');
+    } else {
+      component.control = '<select style="display:' + (options.multi_select ? 'none' : 'inline-block') + '" ' + (options.multi_select ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
+        '<option value="_discard">...</option>' +
+        '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+        '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+        '<option disabled="disabled">---------</option>' +
+        options.select_options +
+        '</select>' +
+        '<a href="#" class="switch-select"><i class="icon-' + (options.multi_select ? 'minus' : 'plus') + '"></i></a>';
+    }
+    return component;
+  };
+
+  components.has_and_belongs_to_many_association_filter_component = function (options) {
+    return this.has_many_association_filter_component(options);
+  };
+
+  components.belongs_to_association_filter_component = function (options) {
+    var select_options = options['select_options'];
+    if (select_options.length > 0) {
+      return this.has_many_association_filter_component(options);
+    }
+    return this.string_filter_component(options);
+  };
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
@@ -6,7 +6,7 @@
     var component = {};
     if (options.check_boxes) {
       component.control = options.checkbox_values.map(function (value) {
-        return new_checkbox(value)
+        return helpers.new_checkbox(value, options);
       }).join('\n');
     } else {
       component.control = '<select style="display:' + helpers.select_input_display(options) + 'class="select-single input-sm form-control">' +

--- a/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/association_filter_component.js
@@ -1,29 +1,22 @@
 (function (components) {
 
+  var helpers = components.helpers;
+
   components.has_many_association_filter_component = function (options) {
     var component = {};
     if (options.check_boxes) {
-      var checked = function (value, applied_filters) {
-        return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
-      };
-      var new_checkbox = function (value) {
-        return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
-          '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
-          '' + value[0] +
-          '</label>';
-      };
       component.control = options.checkbox_values.map(function (value) {
         return new_checkbox(value)
       }).join('\n');
     } else {
-      component.control = '<select style="display:' + (options.multi_select ? 'none' : 'inline-block') + '" ' + (options.multi_select ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
+      component.control = '<select style="display:' + helpers.select_input_display(options) + 'class="select-single input-sm form-control">' +
         '<option value="_discard">...</option>' +
-        '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-        '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+        '<option ' + helpers.present_operator_selected(options) + RailsAdmin.I18n.t("is_present") + '</option>' +
+        '<option ' + helpers.blank_operator_selected(options) + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
         '<option disabled="disabled">---------</option>' +
         options.select_options +
         '</select>' +
-        '<a href="#" class="switch-select"><i class="icon-' + (options.multi_select ? 'minus' : 'plus') + '"></i></a>';
+        '<a href="#" class="switch-select"><i class="icon-' + helpers.plus_or_minus_icon(options.multi_select) + '"></i></a>';
     }
     return component;
   };
@@ -40,4 +33,4 @@
     return this.string_filter_component(options);
   };
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/boolean_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/boolean_filter_component.js
@@ -1,16 +1,19 @@
+
 (function (components) {
+
+  var helpers = components.helpers;
 
   components.boolean_filter_component = function (options) {
     var component = {};
     component.control = '<select class="input-sm form-control" name="' + options.value_name + '">' +
       '<option value="_discard">...</option>' +
-      '<option value="true"' + (options.field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
-      '<option value="false"' + (options.field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
+      '<option value="true"' + true_operator_selected(options) + '>' + RailsAdmin.I18n.t("true") + '</option>' +
+      '<option value="false"' + false_operator_selected(options) + '>' + RailsAdmin.I18n.t("false") + '</option>' +
       '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option ' + helpers.present_operator_selected(options) + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + helpers.blank_operator_selected(options) + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
       '</select>';
     return component;
   };
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/boolean_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/boolean_filter_component.js
@@ -1,0 +1,16 @@
+(function (components) {
+
+  components.boolean_filter_component = function (options) {
+    var component = {};
+    component.control = '<select class="input-sm form-control" name="' + options.value_name + '">' +
+      '<option value="_discard">...</option>' +
+      '<option value="true"' + (options.field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
+      '<option value="false"' + (options.field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    return component;
+  };
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
@@ -1,0 +1,35 @@
+(function (components) {
+
+  components.datetime_filter_component = function (options) {
+    var component = {};
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
+      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
+      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option ' + (options.field_operator == "today" ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
+      '<option ' + (options.field_operator == "yesterday" ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
+      '<option ' + (options.field_operator == "this_week" ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
+      '<option ' + (options.field_operator == "last_week" ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    component.additional_control = '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  };
+
+  components.date_filter_component = function (options) {
+    var component = {};
+    component.control = this.datetime_filter_component(options).control;
+    component.additional_control = '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  };
+
+  components.timestamp_filter_component = function (options) {
+    return this.datetime_filter_component(options);
+  };
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
@@ -1,11 +1,13 @@
 (function (components) {
 
   var helpers = components.helpers;
+  var shared_elements = components.shared_elements;
+
 
   components.datetime_filter_component = function (options) {
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      helpers.between_and_default_options() +
+      shared_elements.between_and_default_options() +
       '<option ' + helpers.today_filter_selected(options) + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
       '<option ' + helpers.yesterday_operator_selected(options) + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
       '<option ' + helpers.this_week_operator_selected(options) + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +

--- a/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
@@ -1,30 +1,32 @@
 (function (components) {
 
+  var helpers = components.helpers;
+
   components.datetime_filter_component = function (options) {
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
-      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
-      '<option ' + (options.field_operator == "today" ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
-      '<option ' + (options.field_operator == "yesterday" ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
-      '<option ' + (options.field_operator == "this_week" ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
-      '<option ' + (options.field_operator == "last_week" ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
+      '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
+      '<option ' + helpers.between_operator_display(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option ' + helpers.today_filter_selected(options) + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
+      '<option ' + helpers.yesterday_operator_selected(options) + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
+      '<option ' + helpers.this_week_operator_selected(options) + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
+      '<option ' + helpers.last_week_operator_selected(options) + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
       '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option ' + helpers.not_null_operator_selected(options) + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + helpers.null_operator_selected(options) + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
       '</select>';
-    component.additional_control = '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
-      '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    component.additional_control = '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + helpers.default_filter_display(options) + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + helpers.between_operator_display(options) + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + helpers.between_operator_display(options) + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
     return component;
   };
 
   components.date_filter_component = function (options) {
     var component = {};
     component.control = this.datetime_filter_component(options).control;
-    component.additional_control = '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
-      '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    component.additional_control = '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator === "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + helpers.between_operator_display(options) + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + helpers.between_operator_display(options) + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
     return component;
   };
 
@@ -32,4 +34,4 @@
     return this.datetime_filter_component(options);
   };
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/date_filter_component.js
@@ -5,8 +5,7 @@
   components.datetime_filter_component = function (options) {
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
-      '<option ' + helpers.between_operator_display(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      helpers.between_and_default_options() +
       '<option ' + helpers.today_filter_selected(options) + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
       '<option ' + helpers.yesterday_operator_selected(options) + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
       '<option ' + helpers.this_week_operator_selected(options) + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +

--- a/app/assets/javascripts/rails_admin/filter-box-components/default_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/default_filter_component.js
@@ -1,0 +1,7 @@
+(function (components) {
+
+  components.default_filter_component = function (options) {
+    return {control: '<input type="text" class="input-sm form-control" name="' + options.value_name + '" value="' + options.field_value + '"/>' }
+  }
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/default_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/default_filter_component.js
@@ -4,4 +4,4 @@
     return {control: '<input type="text" class="input-sm form-control" name="' + options.value_name + '" value="' + options.field_value + '"/>' }
   }
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
@@ -1,0 +1,20 @@
+(function (components) {
+
+  components.enum_filter_component = function (options) {
+    var component = {};
+    var multiple_values = ((options.field_value instanceof Array) ? true : false)
+    component.control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
+      '<option value="_discard">...</option>' +
+      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      options.select_options +
+      '</select>' +
+      '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + options.value_name + '[]"' : '') + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
+      options.select_options +
+      '</select> ' +
+      '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
+    return component;
+  }
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
@@ -13,7 +13,7 @@
       '<option disabled="disabled">---------</option>' +
       options.select_options +
       '</select>' +
-      '<select multiple="multiple" style="display:' + multiple_values_display(multiple_values, options) + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
+      '<select multiple="multiple" style="display:' + helpers.multiple_values_display(multiple_values, options) + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
       options.select_options +
       '</select> ' +
       '<a href="#" class="switch-select"><i class="icon-' + helpers.plus_or_minus_icon(multiple_values) + '"></i></a>';

--- a/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/enum_filter_component.js
@@ -1,20 +1,23 @@
+
 (function (components) {
+
+  var helpers = components.helpers;
 
   components.enum_filter_component = function (options) {
     var component = {};
-    var multiple_values = ((options.field_value instanceof Array) ? true : false)
+    var multiple_values = (options.field_value instanceof Array);
     component.control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
       '<option value="_discard">...</option>' +
-      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option ' + helpers.present_operator_selected(options) + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + helpers.blank_operator_selected(options) + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
       '<option disabled="disabled">---------</option>' +
       options.select_options +
       '</select>' +
-      '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + options.value_name + '[]"' : '') + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
+      '<select multiple="multiple" style="display:' + multiple_values_display(multiple_values, options) + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
       options.select_options +
       '</select> ' +
-      '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
+      '<a href="#" class="switch-select"><i class="icon-' + helpers.plus_or_minus_icon(multiple_values) + '"></i></a>';
     return component;
   }
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/filter-box-helpers.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/filter-box-helpers.js
@@ -1,58 +1,56 @@
 (function (helpers) {
-
-  helpers.selected = function () {
-    return 'selected="selected"';
-  };
-
+  
+  var selected_state = 'selected="selected"';
+  
   helpers.like_operator_selected = function (options) {
-    return (options.field_operator === "like" ? selected() : '');
+    return (options.field_operator === "like" ? selected_state : '');
   };
   
   helpers.is_operator_selected = function (options) {
-    return (options.field_operator === "is" ? selected() : '');
+    return (options.field_operator === "is" ? selected_state : '');
   };
   
   helpers.starts_with_operstor_selected = function (options) {
-    return (options.field_operator === "starts_with" ? selected() : '');
+    return (options.field_operator === "starts_with" ? selected_state : '');
   };
   
   helpers.ends_with_operator_selected = function (options) {
-    return (options.field_operator === "ends_with" ? selected() : '');
+    return (options.field_operator === "ends_with" ? selected_state : '');
   };
 
   helpers.default_operator_selected = function (options) {
-    return (options.field_operator === "default" ? selected() : '');
+    return (options.field_operator === "default" ? selected_state : '');
   };
 
   helpers.between_operator_selected = function (options) {
-    return (options.field_operator === "between" ? selected() : '');
+    return (options.field_operator === "between" ? selected_state : '');
   };
 
   helpers.not_null_operator_selected = function (options) {
-    return (options.field_operator === "_not_null" ? selected() : '');
+    return (options.field_operator === "_not_null" ? selected_state : '');
   };
 
   helpers.null_operator_selected = function (options) {
-    return (options.field_operator === "_null" ? selected() : '');
+    return (options.field_operator === "_null" ? selected_state : '');
   };
 
   helpers.today_operator_selected = function (options) {
-    return (options.field_operator === "today" ? 'selected="selected"' : '')
+    return (options.field_operator === "today" ? selected_state : '')
   };
   helpers.yesterday_operator_selected = function (options) {
-    return (options.field_operator === "yesterday" ? 'selected="selected"' : '')
+    return (options.field_operator === "yesterday" ? selected_state : '')
   };
   helpers.last_week_operator_selected = function (options) {
-    return (options.field_operator === "last_week" ? 'selected="selected"' : '')
+    return (options.field_operator === "last_week" ? selected_state : '')
   };
   helpers.this_week_operator_selected = function (options) {
-    return (options.field_operator === "this_week" ? 'selected="selected"' : '')
+    return (options.field_operator === "this_week" ? selected_state : '')
   };
   helpers.true_operator_selected = function (options) {
-    return (options.field_value === "true" ? 'selected="selected"' : '');
+    return (options.field_value === "true" ? selected_state : '');
   };
   helpers.false_operator_selected = function (options) {
-    return (options.field_value === "false" ? 'selected="selected"' : '');
+    return (options.field_value === "false" ? selected_state : '');
   };
 
   helpers.default_filter_display = function (options) {
@@ -67,9 +65,9 @@
     return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
   };
 
-  helpers.new_checkbox = function (value) {
+  helpers.new_checkbox = function (value, options) {
     return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
-      '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
+      '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + helpers.checked(value, options.applied_filters) + ' />' +
       '' + value[0] +
       '</label>';
   };

--- a/app/assets/javascripts/rails_admin/filter-box-components/filter-box-helpers.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/filter-box-helpers.js
@@ -1,0 +1,95 @@
+(function (helpers) {
+
+  helpers.selected = function () {
+    return 'selected="selected"';
+  };
+
+  helpers.like_operator_selected = function (options) {
+    return (options.field_operator === "like" ? selected() : '');
+  };
+  
+  helpers.is_operator_selected = function (options) {
+    return (options.field_operator === "is" ? selected() : '');
+  };
+  
+  helpers.starts_with_operstor_selected = function (options) {
+    return (options.field_operator === "starts_with" ? selected() : '');
+  };
+  
+  helpers.ends_with_operator_selected = function (options) {
+    return (options.field_operator === "ends_with" ? selected() : '');
+  };
+
+  helpers.default_operator_selected = function (options) {
+    return (options.field_operator === "default" ? selected() : '');
+  };
+
+  helpers.between_operator_selected = function (options) {
+    return (options.field_operator === "between" ? selected() : '');
+  };
+
+  helpers.not_null_operator_selected = function (options) {
+    return (options.field_operator === "_not_null" ? selected() : '');
+  };
+
+  helpers.null_operator_selected = function (options) {
+    return (options.field_operator === "_null" ? selected() : '');
+  };
+
+  helpers.today_operator_selected = function (options) {
+    return (options.field_operator === "today" ? 'selected="selected"' : '')
+  };
+  helpers.yesterday_operator_selected = function (options) {
+    return (options.field_operator === "yesterday" ? 'selected="selected"' : '')
+  };
+  helpers.last_week_operator_selected = function (options) {
+    return (options.field_operator === "last_week" ? 'selected="selected"' : '')
+  };
+  helpers.this_week_operator_selected = function (options) {
+    return (options.field_operator === "this_week" ? 'selected="selected"' : '')
+  };
+  helpers.true_operator_selected = function (options) {
+    return (options.field_value === "true" ? 'selected="selected"' : '');
+  };
+  helpers.false_operator_selected = function (options) {
+    return (options.field_value === "false" ? 'selected="selected"' : '');
+  };
+
+  helpers.default_filter_display = function (options) {
+    return ((!options.field_operator || options.field_operator === "default") ? 'inline-block' : 'none');
+  };
+  
+  helpers.between_operator_display = function (options) {
+    return ((options.field_operator === "between") ? 'inline-block' : 'none');
+  };
+
+  helpers.checked = function (value, applied_filters) {
+    return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
+  };
+
+  helpers.new_checkbox = function (value) {
+    return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
+      '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
+      '' + value[0] +
+      '</label>';
+  };
+
+  helpers.select_input_display = function (options) {
+    return (options.multi_select ? 'none' : 'inline-block') + '" ' + (options.multi_select ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + ' ';
+  };
+
+  helpers.present_operator_selected = function (options) {
+    return (options.field_value === "_present" ? 'selected="selected"' : '') + ' value="_present">';
+  };
+  helpers.blank_operator_selected = function (options) {
+    return (options.field_value === "_blank" ? 'selected="selected"' : '');
+  };
+  helpers.plus_or_minus_icon = function (multi) {
+    return (multi ? 'minus' : 'plus');
+  };
+
+  helpers.multiple_values_display = function (multiple_values, options) {
+    return (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + options.value_name + '[]"' : '');
+  };
+  
+}(FilterBoxComponents.helpers));

--- a/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
@@ -12,7 +12,7 @@
       '</select>';
     component.additional_control =
       '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (foptions.ield_value[1] || '') + '" /> ' +
+      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
       '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
     return component;
   };

--- a/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
@@ -1,19 +1,20 @@
 (function (components) {
 
+  var helpers = components.helpers;
+
   components.number_filter_component = function (options) {
     var component = {};
-
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
-      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
+      '<option ' + helpers.between_operator_selected(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
       '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option ' + helpers.not_null_operator_selected(options) + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + helpers.null_operator_selected(options) + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
       '</select>';
     component.additional_control =
-      '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
-      '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+      '<input class="additional-fieldset default input-sm form-control" style="display:' + helpers.default_filter_display(options) + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + helpers.between_operator_display(options) + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' +  helpers.between_operator_display(options) + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
     return component;
   };
 
@@ -29,4 +30,4 @@
     return this.number_filter_component(options);
   };
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
@@ -1,11 +1,12 @@
 (function (components) {
 
   var helpers = components.helpers;
+  var shared_elements = components.shared_elements;
 
   components.number_filter_component = function (options) {
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      helpers.between_and_default_options() +
+      shared_elements.between_and_default_options(options) +
       '<option disabled="disabled">---------</option>' +
       '<option ' + helpers.not_null_operator_selected(options) + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
       '<option ' + helpers.null_operator_selected(options) + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +

--- a/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
@@ -1,0 +1,32 @@
+(function (components) {
+
+  components.number_filter_component = function (options) {
+    var component = {};
+
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
+      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
+      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    component.additional_control =
+      '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (foptions.ield_value[1] || '') + '" /> ' +
+      '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  };
+
+  components.integer_filter_component = function (options) {
+    return this.number_filter_component(options);
+  };
+
+  components.decimal_filter_component = function (options) {
+    return this.number_filter_component(options);
+  };
+
+  components.float_filter_component = function (options) {
+    return this.number_filter_component(options);
+  };
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/number_filter_component.js
@@ -5,8 +5,7 @@
   components.number_filter_component = function (options) {
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
-      '<option ' + helpers.between_operator_selected(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      helpers.between_and_default_options() +
       '<option disabled="disabled">---------</option>' +
       '<option ' + helpers.not_null_operator_selected(options) + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
       '<option ' + helpers.null_operator_selected(options) + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +

--- a/app/assets/javascripts/rails_admin/filter-box-components/shared_elements.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/shared_elements.js
@@ -3,7 +3,7 @@
   var shared_elements = components.shared_elements;
   var helpers = components.helpers;
 
-  shared_elements.between_and_default_options = function () {
+  shared_elements.between_and_default_options = function (options) {
     return '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
            '<option ' + helpers.between_operator_selected(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>';
   }

--- a/app/assets/javascripts/rails_admin/filter-box-components/shared_elements.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/shared_elements.js
@@ -1,0 +1,11 @@
+(function(components){
+
+  var shared_elements = components.shared_elements;
+  var helpers = components.helpers;
+
+  shared_elements.between_and_default_options = function () {
+    return '<option ' + helpers.default_operator_selected(options) + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
+           '<option ' + helpers.between_operator_selected(options) + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>';
+  }
+
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/string_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/string_filter_component.js
@@ -1,18 +1,20 @@
+
 (function (components) {
+  var helpers = components.helpers;
 
   components.string_filter_component = function (options) {
     var control;
     var component = {};
     component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + options.field_operator + '" name="' + options.operator_name + '">' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "like" ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "is" ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "ends_with" ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + helpers.like_operator_selected(options) + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + helpers.is_operator_selected(options) + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + helpers.starts_with_operstor_selected(options) + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + helpers.ends_with_operator_selected(options) + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
       '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '</select>'
-    component.additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (options.field_operator == "_blank" || options.field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + options.value_name + '" value="' + options.field_value + '" />';
+      '<option ' + helpers.not_null_operator_selected(options) + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + helpers.null_operator_selected(options) + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    component.additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (options.field_operator === "_blank" || options.field_operator === "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + options.value_name + '" value="' + options.field_value + '" />';
     return component;
   };
 
@@ -20,4 +22,4 @@
     return this.string_filter_component(options)
   };
 
-})(FilterBoxComponents);
+}(FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/filter-box-components/string_filter_component.js
+++ b/app/assets/javascripts/rails_admin/filter-box-components/string_filter_component.js
@@ -1,0 +1,23 @@
+(function (components) {
+
+  components.string_filter_component = function (options) {
+    var control;
+    var component = {};
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + options.field_operator + '" name="' + options.operator_name + '">' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "like" ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "is" ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "ends_with" ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>'
+    component.additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (options.field_operator == "_blank" || options.field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + options.value_name + '" value="' + options.field_value + '" />';
+    return component;
+  };
+
+  components.text_filter_component = function (options) {
+    return this.string_filter_component(options)
+  };
+
+})(FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/ra.filter-box-components.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box-components.js
@@ -1,6 +1,7 @@
 
 var FilterBoxComponents = {
   helpers: {},
+  shared_elements: {},
   create: function(options){
     var fieldFactoryName = options.field_type + '_filter_component';
     try {

--- a/app/assets/javascripts/rails_admin/ra.filter-box-components.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box-components.js
@@ -1,5 +1,6 @@
 
 var FilterBoxComponents = {
+  helpers: {},
   create: function(options){
     var fieldFactoryName = options.field_type + '_filter_component';
     try {

--- a/app/assets/javascripts/rails_admin/ra.filter-box-components.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box-components.js
@@ -1,0 +1,11 @@
+
+var FilterBoxComponents = {
+  create: function(options){
+    var fieldFactoryName = options.field_type + '_filter_component';
+    try {
+      return this[fieldFactoryName](options);
+    } catch (e) {
+      throw('FilterComponent.createError: ' + e + '. The most likely fix is to create a function in "FilterComponents" named "' + fieldFactoryName + '(options)" that returns a filter component HTML.')
+    }
+  }
+};

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -81,4 +81,4 @@
       $(this).siblings('.additional-fieldset').hide('slow');
     }
   });
-})(jQuery, FilterBoxComponents);
+}(jQuery, FilterBoxComponents));

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -1,3 +1,6 @@
+//=  require 'rails_admin/ra.filter-box-components'
+//=  require_tree './filter-box-components'
+
 (function ($, componentFactory) {
 
   var filters;

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -15,7 +15,7 @@
       var field_value = options['value'];
       var field_operator = options['operator'];
       var select_options = options['select_options'];
-      var multi_select = options['multiple'];
+      var multi_select = options['multi_select'];
       var check_boxes = options['check_boxes'];
       var checkbox_values = options['checkbox_values'];
       var applied_filters = options['applied_filters'];
@@ -87,6 +87,7 @@
           '</select>'
           additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (field_operator == "_blank" || field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
           break;
+        case 'has_many_association':
         case 'has_and_belongs_to_many_association':
           multiple_values = multi_select;
           if(check_boxes){

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -2,6 +2,10 @@
 
   var filters;
 
+  var checked = function (value, applied_filters) {
+    return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
+  };
+
   $.filters = filters = {
     append: function(options) {
       options = options || {};
@@ -11,6 +15,10 @@
       var field_value = options['value'];
       var field_operator = options['operator'];
       var select_options = options['select_options'];
+      var multi_select = options['multiple'];
+      var check_boxes = options['check_boxes'];
+      var checkbox_values = options['checkbox_values'];
+      var applied_filters = options['applied_filters'];
       var index = options['index'];
       var value_name    = 'f[' +  field_name + '][' + index + '][v]';
       var operator_name = 'f[' +  field_name + '][' + index + '][o]';
@@ -79,6 +87,30 @@
           '</select>'
           additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (field_operator == "_blank" || field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
           break;
+        case 'has_and_belongs_to_many_association':
+          multiple_values = multi_select;
+          if(check_boxes){
+            var new_checkbox = function(value) {
+               return '<input style="display:inline-block" name="' + value_name + '[]" data-name="' + value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="'+ value[1] +'" ' + checked(value, applied_filters) + ' />' +
+                      '<label for="' + value_name + '[]">' + value[0] + '</label>';
+            };
+            control = checkbox_values.map(function(value){
+              return new_checkbox(value)
+            }).join('<br>\n');
+          } else {
+            control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + value_name + '"') + ' data-name="' + value_name + '" class="select-single input-sm form-control">' +
+              '<option value="_discard">...</option>' +
+              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+              '<option disabled="disabled">---------</option>' +
+              select_options +
+              '</select>' +
+              '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + value_name + '[]"' : '') + ' data-name="' + value_name + '[]" class="select-multiple input-sm form-control">' +
+              select_options +
+              '</select>' +
+              '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
+          }
+          break;
         case 'integer':
         case 'decimal':
         case 'float':
@@ -88,14 +120,14 @@
             '<option disabled="disabled">---------</option>' +
             '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") +'</option>' +
             '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-          '</select>'
+          '</select>';
           additional_control =
           '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
           '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' +
           '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[2] || '') + '" />';
           break;
         default:
-          control = '<input type="text" class="input-sm form-control" name="' + value_name + '" value="' + field_value + '"/> ';
+          control = '<input type="text" class="input-sm form-control" name="' + value_name + '" value="' + field_value + '"/>';
           break;
       }
 

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -146,6 +146,10 @@ var FilterComponents = {
   },
   defaultFilterComponent: function (options) {
     return {control: '<input type="text" class="input-sm form-control" name="' + options.value_name + '" value="' + options.field_value + '"/>' }
+  },
+  create: function(filterOptions){
+    var field = filterOptions.field_type.toCamelCase() + 'FilterComponent';
+    return this[field](filterOptions);
   }
 };
 
@@ -171,16 +175,10 @@ var FilterComponents = {
     }
   };
 
-
-  var fieldFactory = function(filterOptions){
-    var field = filterOptions.field_type.toCamelCase() + 'FilterComponent';
-    return componentFactory[field](filterOptions);
-  };
-
   $.filters = filters = {
     append: function (options) {
       var filterOptions = filterOptionsHandeler(options) || {};
-      var component = fieldFactory(filterOptions);
+      var component = componentFactory.create(filterOptions);
       var control = component.control;
       var additional_control = component.additional_control;
 
@@ -199,7 +197,7 @@ var FilterComponents = {
 
       $("hr.filters_box:hidden").show('slow');
     }
-  }
+  };
 
   $(document).on('click', "#filters a", function (e) {
     e.preventDefault();

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -1,163 +1,8 @@
-String.prototype.toCamelCase = function() {
-  return this.replace(/^([A-Z])|[\s-_](\w)/g, function(match, p1, p2, offset) {
-    if (p2) return p2.toUpperCase();
-    return p1.toLowerCase();
-  });
-};
-
-var FilterComponents = {
-  booleanFilterComponent: function (options) {
-    var component = {};
-    component.control = '<select class="input-sm form-control" name="' + options.value_name + '">' +
-      '<option value="_discard">...</option>' +
-      '<option value="true"' + (options.field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
-      '<option value="false"' + (options.field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
-      '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '</select>';
-    return component;
-  },
-  dateFilterComponent: function (options) {
-    var component = {};
-    component.additional_control = '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
-      '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
-    return component;
-  },
-  datetimeFilterComponent: function (options) {
-    var component = {};
-
-    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
-      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
-      '<option ' + (options.field_operator == "today" ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
-      '<option ' + (options.field_operator == "yesterday" ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
-      '<option ' + (options.field_operator == "this_week" ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
-      '<option ' + (options.field_operator == "last_week" ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
-      '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '</select>';
-    component.additional_control = '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
-      '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
-    return component;
-  },
-  timestampFilterComponent: function (options) {
-    return this.datetimeFilterComponent(options);
-  },
-  enumFilterComponent: function (options) {
-    var component = {};
-    var multiple_values = ((options.field_value instanceof Array) ? true : false)
-    component.control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
-      '<option value="_discard">...</option>' +
-      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '<option disabled="disabled">---------</option>' +
-      options.select_options +
-      '</select>' +
-      '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + options.value_name + '[]"' : '') + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
-      options.select_options +
-      '</select> ' +
-      '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
-    return component;
-  },
-  stringFilterComponent: function (options) {
-    var control;
-    var component = {};
-    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + options.field_operator + '" name="' + options.operator_name + '">' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "like" ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "is" ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
-      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "ends_with" ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
-      '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '</select>'
-    component.additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (options.field_operator == "_blank" || options.field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + options.value_name + '" value="' + options.field_value + '" />';
-    return component;
-  },
-  textFilterComponent: function (options) {
-    return this.stringFilterComponent(options)
-  },
-  hasManyAssociationFilterComponent: function (options) {
-    var component = {};
-    if (options.check_boxes) {
-      var checked = function (value, applied_filters) {
-        return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
-      }
-      var new_checkbox = function (value) {
-        return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
-          '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
-          '' + value[0] +
-          '</label>';
-      };
-      component.control = options.checkbox_values.map(function (value) {
-        return new_checkbox(value)
-      }).join('\n');
-    } else {
-      component.control = '<select style="display:' + (options.multi_select ? 'none' : 'inline-block') + '" ' + (options.multi_select ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
-        '<option value="_discard">...</option>' +
-        '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-        '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-        '<option disabled="disabled">---------</option>' +
-        options.select_options +
-        '</select>' +
-        '<a href="#" class="switch-select"><i class="icon-' + (options.multi_select ? 'minus' : 'plus') + '"></i></a>';
-    }
-    return component;
-  },
-  hasAndBelongsToManyAssociationFilterComponent: function (options) {
-    return this.hasManyAssociationFilterComponent(options);
-  },
-  belongsToAssociationFilterComponent: function (options) {
-    var select_options = options['select_options'];
-    if (select_options.length > 0) {
-      return this.hasManyAssociationFilterComponent(options);
-    } else  {
-      return this.stringFilterComponent(options);
-    }
-  },
-  numberFilterComponent: function (options) {
-    var component = {};
-
-    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
-      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
-      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
-      '<option disabled="disabled">---------</option>' +
-      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-      '</select>';
-    component.additional_control =
-      '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
-      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (foptions.ield_value[1] || '') + '" /> ' +
-      '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
-    return component;
-  },
-  integerFilterComponent: function (options) {
-    return this.numberFilterComponent(options);
-  },
-  decimalFilterComponent: function (options) {
-    return this.numberFilterComponent(options);
-  },
-  floatFilterComponent: function (options) {
-    return this.numberFilterComponent(options);
-  },
-  defaultFilterComponent: function (options) {
-    return {control: '<input type="text" class="input-sm form-control" name="' + options.value_name + '" value="' + options.field_value + '"/>' }
-  },
-  create: function(filterOptions){
-    var field = filterOptions.field_type.toCamelCase() + 'FilterComponent';
-    return this[field](filterOptions);
-  }
-};
-
 (function ($, componentFactory) {
 
   var filters;
   
-  var filterOptionsHandeler = function (options) {
+  var filterOptionsTransformer = function (options) {
     return {
       field_label: options['label'],
       field_name: options['name'],
@@ -177,15 +22,13 @@ var FilterComponents = {
 
   $.filters = filters = {
     append: function (options) {
-      var filterOptions = filterOptionsHandeler(options) || {};
+      var filterOptions = filterOptionsTransformer(options);
       var component = componentFactory.create(filterOptions);
-      var control = component.control;
-      var additional_control = component.additional_control;
 
       var $content = $('<p>')
         .addClass('filter form-search')
         .append('<span class="label label-info form-label"><a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw icon-white"></i>' + filterOptions.field_label + '</a></span>')
-        .append('&nbsp;' + control + '&nbsp;' + (additional_control || ''));
+        .append('&nbsp;' + component.control + '&nbsp;' + (component.additional_control || ''));
 
       $('#filters_box').append($content);
 
@@ -238,4 +81,4 @@ var FilterComponents = {
       $(this).siblings('.additional-fieldset').hide('slow');
     }
   });
-})(jQuery, FilterComponents);
+})(jQuery, FilterBoxComponents);

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -1,5 +1,5 @@
-//=  require 'rails_admin/ra.filter-box-components'
-//=  require_tree './filter-box-components'
+//= require rails_admin/ra.filter-box-components
+//= require_tree ./filter-box-components
 
 (function ($, componentFactory) {
 

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -1,140 +1,192 @@
-(function($) {
+String.prototype.toCamelCase = function() {
+  return this.replace(/^([A-Z])|[\s-_](\w)/g, function(match, p1, p2, offset) {
+    if (p2) return p2.toUpperCase();
+    return p1.toLowerCase();
+  });
+};
+
+var FilterComponents = {
+  booleanFilterComponent: function (options) {
+    var component = {};
+    component.control = '<select class="input-sm form-control" name="' + options.value_name + '">' +
+      '<option value="_discard">...</option>' +
+      '<option value="true"' + (options.field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
+      '<option value="false"' + (options.field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    return component;
+  },
+  dateFilterComponent: function (options) {
+    var component = {};
+    component.additional_control = '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  },
+  datetimeFilterComponent: function (options) {
+    var component = {};
+
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
+      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
+      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option ' + (options.field_operator == "today" ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
+      '<option ' + (options.field_operator == "yesterday" ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
+      '<option ' + (options.field_operator == "this_week" ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
+      '<option ' + (options.field_operator == "last_week" ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    component.additional_control = '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[1] || '') + '" /> ' +
+      '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  },
+  timestampFilterComponent: function (options) {
+    return this.datetimeFilterComponent(options);
+  },
+  enumFilterComponent: function (options) {
+    var component = {};
+    var multiple_values = ((options.field_value instanceof Array) ? true : false)
+    component.control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
+      '<option value="_discard">...</option>' +
+      '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      options.select_options +
+      '</select>' +
+      '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + options.value_name + '[]"' : '') + ' data-name="' + options.value_name + '[]" class="select-multiple input-sm form-control">' +
+      options.select_options +
+      '</select> ' +
+      '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
+    return component;
+  },
+  stringFilterComponent: function (options) {
+    var control;
+    var component = {};
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + options.field_operator + '" name="' + options.operator_name + '">' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "like" ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "is" ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
+      '<option data-additional-fieldset="additional-fieldset"' + (options.field_operator == "ends_with" ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>'
+    component.additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (options.field_operator == "_blank" || options.field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + options.value_name + '" value="' + options.field_value + '" />';
+    return component;
+  },
+  textFilterComponent: function (options) {
+    return this.stringFilterComponent(options)
+  },
+  hasManyAssociationFilterComponent: function (options) {
+    var component = {};
+    if (options.check_boxes) {
+      var checked = function (value, applied_filters) {
+        return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
+      }
+      var new_checkbox = function (value) {
+        return '<label class="checkbox-inline" for="' + options.value_name + '[]">' +
+          '<input style="display:inline-block" name="' + options.value_name + '[]" data-name="' + options.value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="' + value[1] + '" ' + checked(value, options.applied_filters) + ' />' +
+          '' + value[0] +
+          '</label>';
+      };
+      component.control = options.checkbox_values.map(function (value) {
+        return new_checkbox(value)
+      }).join('\n');
+    } else {
+      component.control = '<select style="display:' + (options.multi_select ? 'none' : 'inline-block') + '" ' + (options.multi_select ? '' : 'name="' + options.value_name + '"') + ' data-name="' + options.value_name + '" class="select-single input-sm form-control">' +
+        '<option value="_discard">...</option>' +
+        '<option ' + (options.field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+        '<option ' + (options.field_value == "_blank" ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+        '<option disabled="disabled">---------</option>' +
+        options.select_options +
+        '</select>' +
+        '<a href="#" class="switch-select"><i class="icon-' + (options.multi_select ? 'minus' : 'plus') + '"></i></a>';
+    }
+    return component;
+  },
+  hasAndBelongsToManyAssociationFilterComponent: function (options) {
+    return this.hasManyAssociationFilterComponent(options);
+  },
+  belongsToAssociationFilterComponent: function (options) {
+    var select_options = options['select_options'];
+    if (select_options.length > 0) {
+      return this.hasManyAssociationFilterComponent(options);
+    } else  {
+      return this.stringFilterComponent(options);
+    }
+  },
+  numberFilterComponent: function (options) {
+    var component = {};
+
+    component.control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + options.operator_name + '">' +
+      '<option ' + (options.field_operator == "default" ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
+      '<option ' + (options.field_operator == "between" ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+      '<option disabled="disabled">---------</option>' +
+      '<option ' + (options.field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+      '<option ' + (options.field_operator == "_null" ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
+      '</select>';
+    component.additional_control =
+      '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!options.field_operator || options.field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[0] || '') + '" /> ' +
+      '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (foptions.ield_value[1] || '') + '" /> ' +
+      '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((options.field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + options.field_type + '" name="' + options.value_name + '[]" value="' + (options.field_value[2] || '') + '" />';
+    return component;
+  },
+  integerFilterComponent: function (options) {
+    return this.numberFilterComponent(options);
+  },
+  decimalFilterComponent: function (options) {
+    return this.numberFilterComponent(options);
+  },
+  floatFilterComponent: function (options) {
+    return this.numberFilterComponent(options);
+  },
+  defaultFilterComponent: function (options) {
+    return {control: '<input type="text" class="input-sm form-control" name="' + options.value_name + '" value="' + options.field_value + '"/>' }
+  }
+};
+
+(function ($, componentFactory) {
 
   var filters;
+  
+  var filterOptionsHandeler = function (options) {
+    return {
+      field_label: options['label'],
+      field_name: options['name'],
+      field_type: options['type'],
+      field_value: options['value'],
+      field_operator: options['operator'],
+      select_options: options['select_options'],
+      multi_select: options['multi_select'],
+      check_boxes: options['check_boxes'],
+      checkbox_values: options['checkbox_values'],
+      applied_filters: options['applied_filters'],
+      index: options['index'],
+      value_name: 'f[' + options['name'] + '][' + options['index'] + '][v]',
+      operator_name: 'f[' + options['name'] + '][' + options['index'] + '][o]'
+    }
+  };
 
-  var checked = function (value, applied_filters) {
-    return $.inArray(value[1], applied_filters) !== -1 ? 'checked="checked"' : '';
+
+  var fieldFactory = function(filterOptions){
+    var field = filterOptions.field_type.toCamelCase() + 'FilterComponent';
+    return componentFactory[field](filterOptions);
   };
 
   $.filters = filters = {
-    append: function(options) {
-      options = options || {};
-      var field_label = options['label'];
-      var field_name  = options['name'];
-      var field_type  = options['type'];
-      var field_value = options['value'];
-      var field_operator = options['operator'];
-      var select_options = options['select_options'];
-      var multi_select = options['multi_select'];
-      var check_boxes = options['check_boxes'];
-      var checkbox_values = options['checkbox_values'];
-      var applied_filters = options['applied_filters'];
-      var index = options['index'];
-      var value_name    = 'f[' +  field_name + '][' + index + '][v]';
-      var operator_name = 'f[' +  field_name + '][' + index + '][o]';
-      var control = null;
-      var additional_control = null;
-
-      switch(field_type) {
-        case 'boolean':
-          var control = '<select class="input-sm form-control" name="' + value_name + '">' +
-            '<option value="_discard">...</option>' +
-            '<option value="true"' + (field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
-            '<option value="false"' + (field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
-            '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-            '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-          '</select>';
-          break;
-        case 'date':
-          additional_control =
-          '<input size="20" class="date additional-fieldset default input-sm form-control" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
-          '<input size="20" placeholder="-∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' +
-          '<input size="20" placeholder="∞" class="date additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[2] || '') + '" />';
-        case 'datetime':
-        case 'timestamp':
-          control = control || '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + operator_name + '">' +
-            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
-            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
-            '<option ' + (field_operator == "today"   ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
-            '<option ' + (field_operator == "yesterday"   ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
-            '<option ' + (field_operator == "this_week"   ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
-            '<option ' + (field_operator == "last_week"   ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
-            '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-          '</select>'
-          additional_control = additional_control ||
-          '<input size="25" class="datetime additional-fieldset default input-sm form-control" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
-          '<input size="25" placeholder="-∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' +
-          '<input size="25" placeholder="∞" class="datetime additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[2] || '') + '" />';
-          break;
-        case 'enum':
-          var multiple_values = ((field_value instanceof Array) ? true : false)
-          control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + value_name + '"') + ' data-name="' + value_name + '" class="select-single input-sm form-control">' +
-              '<option value="_discard">...</option>' +
-              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-              '<option disabled="disabled">---------</option>' +
-              select_options +
-            '</select>' +
-            '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + value_name + '[]"' : '') + ' data-name="' + value_name + '[]" class="select-multiple input-sm form-control">' +
-              select_options +
-            '</select> ' +
-            '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
-        break;
-        case 'string':
-        case 'text':
-        case 'belongs_to_association':
-          control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + field_operator + '" name="' + operator_name + '">' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "is"          ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "ends_with"   ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
-            '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null"    ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-            '<option ' + (field_operator == "_null"      ? 'selected="selected"' : '') + ' value="_null">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-          '</select>'
-          additional_control = '<input class="additional-fieldset input-sm form-control" style="display:' + (field_operator == "_blank" || field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
-          break;
-        case 'has_many_association':
-        case 'has_and_belongs_to_many_association':
-          multiple_values = multi_select;
-          if(check_boxes){
-            var new_checkbox = function(value) {
-               return '<input style="display:inline-block" name="' + value_name + '[]" data-name="' + value_name + '[]" class="checkbox input-sm form-control" type="checkbox" value="'+ value[1] +'" ' + checked(value, applied_filters) + ' />' +
-                      '<label for="' + value_name + '[]">' + value[0] + '</label>';
-            };
-            control = checkbox_values.map(function(value){
-              return new_checkbox(value)
-            }).join('<br>\n');
-          } else {
-            control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + value_name + '"') + ' data-name="' + value_name + '" class="select-single input-sm form-control">' +
-              '<option value="_discard">...</option>' +
-              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
-              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-              '<option disabled="disabled">---------</option>' +
-              select_options +
-              '</select>' +
-              '<select multiple="multiple" style="display:' + (multiple_values ? 'inline-block' : 'none') + '" ' + (multiple_values ? 'name="' + value_name + '[]"' : '') + ' data-name="' + value_name + '[]" class="select-multiple input-sm form-control">' +
-              select_options +
-              '</select>' +
-              '<a href="#" class="switch-select"><i class="icon-' + (multiple_values ? 'minus' : 'plus') + '"></i></a>';
-          }
-          break;
-        case 'integer':
-        case 'decimal':
-        case 'float':
-          control = '<select class="switch-additionnal-fieldsets input-sm form-control" name="' + operator_name + '">' +
-            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("number") + '</option>' +
-            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
-            '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") +'</option>' +
-            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
-          '</select>';
-          additional_control =
-          '<input class="additional-fieldset default input-sm form-control" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
-          '<input placeholder="-∞" class="additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' +
-          '<input placeholder="∞" class="additional-fieldset between input-sm form-control" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[2] || '') + '" />';
-          break;
-        default:
-          control = '<input type="text" class="input-sm form-control" name="' + value_name + '" value="' + field_value + '"/>';
-          break;
-      }
+    append: function (options) {
+      var filterOptions = filterOptionsHandeler(options) || {};
+      var component = fieldFactory(filterOptions);
+      var control = component.control;
+      var additional_control = component.additional_control;
 
       var $content = $('<p>')
         .addClass('filter form-search')
-        .append('<span class="label label-info form-label"><a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw icon-white"></i>' + field_label + '</a></span>')
+        .append('<span class="label label-info form-label"><a href="#delete" class="delete"><i class="fa fa-trash-o fa-fw icon-white"></i>' + filterOptions.field_label + '</a></span>')
         .append('&nbsp;' + control + '&nbsp;' + (additional_control || ''));
 
       $('#filters_box').append($content);
@@ -142,35 +194,35 @@
       $content.find('.date, .datetime').datetimepicker({
         locale: RailsAdmin.I18n.locale,
         showTodayButton: true,
-        format: options['datetimepicker_format']
+        format: filterOptions['datetimepicker_format']
       });
 
       $("hr.filters_box:hidden").show('slow');
     }
   }
 
-  $(document).on('click', "#filters a", function(e) {
+  $(document).on('click', "#filters a", function (e) {
     e.preventDefault();
     $.filters.append({
       label: $(this).data('field-label'),
-      name:  $(this).data('field-name'),
-      type:  $(this).data('field-type'),
+      name: $(this).data('field-name'),
+      type: $(this).data('field-type'),
       value: $(this).data('field-value'),
       operator: $(this).data('field-operator'),
       select_options: $(this).data('field-options'),
-      index: $.now().toString().slice(6,11),
+      index: $.now().toString().slice(6, 11),
       datetimepicker_format: $(this).data('field-datetimepicker-format')
     });
   });
 
-  $(document).on('click', "#filters_box .delete", function(e) {
+  $(document).on('click', "#filters_box .delete", function (e) {
     e.preventDefault();
     form = $(this).parents('form');
     $(this).parents('.filter').remove();
     !$("#filters_box").children().length && $("hr.filters_box:visible").hide('slow');
   });
 
-  $(document).on('click', "#filters_box .switch-select", function(e) {
+  $(document).on('click', "#filters_box .switch-select", function (e) {
     e.preventDefault();
     var selected_select = $(this).siblings('select:visible');
     var not_selected_select = $(this).siblings('select:hidden');
@@ -179,13 +231,13 @@
     $(this).find('i').toggleClass("icon-plus icon-minus")
   });
 
-  $(document).on('change', "#filters_box .switch-additionnal-fieldsets", function(e) {
+  $(document).on('change', "#filters_box .switch-additionnal-fieldsets", function (e) {
     var selected_option = $(this).find('option:selected');
-    if(klass = $(selected_option).data('additional-fieldset')) {
+    if (klass = $(selected_option).data('additional-fieldset')) {
       $(this).siblings('.additional-fieldset:not(.' + klass + ')').hide('slow');
       $(this).siblings('.' + klass).show('slow');
     } else {
       $(this).siblings('.additional-fieldset').hide('slow');
     }
   });
-})( jQuery );
+})(jQuery, FilterComponents);

--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -1,3 +1,4 @@
+
 /*
  * RailsAdmin filtering multiselect @VERSION
  *

--- a/app/assets/javascripts/rails_admin/rails_admin.js
+++ b/app/assets/javascripts/rails_admin/rails_admin.js
@@ -7,8 +7,6 @@
 //=  require 'rails_admin/moment-with-locales'
 //=  require 'rails_admin/bootstrap-datetimepicker'
 //=  require 'rails_admin/jquery.colorpicker'
-//=  require 'rails_admin/ra.filter-box-components'
-//=  require_tree './filter-box-components'
 //=  require 'rails_admin/ra.filter-box'
 //=  require 'rails_admin/ra.filtering-multiselect'
 //=  require 'rails_admin/ra.filtering-select'

--- a/app/assets/javascripts/rails_admin/rails_admin.js
+++ b/app/assets/javascripts/rails_admin/rails_admin.js
@@ -7,6 +7,8 @@
 //=  require 'rails_admin/moment-with-locales'
 //=  require 'rails_admin/bootstrap-datetimepicker'
 //=  require 'rails_admin/jquery.colorpicker'
+//=  require 'rails_admin/ra.filter-box-components'
+//=  require_tree './filter-box-components'
 //=  require 'rails_admin/ra.filter-box'
 //=  require 'rails_admin/ra.filtering-multiselect'
 //=  require 'rails_admin/ra.filtering-select'

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -120,7 +120,7 @@ module RailsAdmin
     end
 
     def get_collection(model_config, scope, pagination)
-      associations = model_config.list.fields.select { |f| f.type == :belongs_to_association && !f.polymorphic? }.collect { |f| f.association.name }
+      associations = model_config.list.fields.select { |f| (f.type == :belongs_to_association || f.type == :has_many_association || f.type == :has_and_belongs_to_many_association) && !f.polymorphic? }.collect { |f| f.association.name }
       options = {}
       options = options.merge(page: (params[Kaminari.config.param_name] || 1).to_i, per: (params[:per] || model_config.list.items_per_page)) if pagination
       options = options.merge(include: associations) unless associations.blank?

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -121,7 +121,6 @@ module RailsAdmin
 
     def get_collection(model_config, scope, pagination)
       associations = model_config.list.fields.select { |f| f.try(:eager_load?) }.collect { |f| f.association.name }
-	  raise("change to eager_load?")
       options = {}
       options = options.merge(page: (params[Kaminari.config.param_name] || 1).to_i, per: (params[:per] || model_config.list.items_per_page)) if pagination
       options = options.merge(include: associations) unless associations.blank?

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -10,11 +10,11 @@ module RailsAdmin
     end
 
     def get_indicator(percent)
-      return '' if percent < 0          # none
-      return 'info' if percent < 34     # < 1/100 of max
-      return 'success' if percent < 67  # < 1/10 of max
-      return 'warning' if percent < 84  # < 1/3 of max
-      'danger'                          # > 1/3 of max
+      return '' if percent < 0 # none
+      return 'info' if percent < 34 # < 1/100 of max
+      return 'success' if percent < 67 # < 1/10 of max
+      return 'warning' if percent < 84 # < 1/3 of max
+      'danger' # > 1/3 of max
     end
 
     def get_column_sets(properties)
@@ -66,14 +66,20 @@ module RailsAdmin
           fail "#{filter_name} is not currently filterable; filterable fields are #{filterable_fields.map(&:name).join(', ')}"
         end
         case field.type
-        when :enum
-          options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).enum, filter_hash['v'])
-        when :date, :datetime, :time
-          options[:datetimepicker_format] = field.parser.to_momentjs
+          when :enum
+            options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).enum, filter_hash['v'])
+          when :has_and_belongs_to_many_association, :has_many_association
+            options[:multiple] = field.with(object: @abstract_model.model.new).multiple
+            options[:check_boxes] = field.with(object: @abstract_model.model.new).check_boxes
+            options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).filter_by, filter_hash['v']) unless options[:check_boxes]
+            options[:checkbox_values] = field.with(object: @abstract_model.model.new).filter_by if options[:check_boxes]
+            options[:applied_filters] = filter_hash['v'].map(&:to_i) if filter_hash['v'].is_a?(Array)
+          when :date, :datetime, :time
+            options[:datetimepicker_format] = field.parser.to_momentjs
         end
         options[:label] = field.label
-        options[:name]  = field.name
-        options[:type]  = field.type
+        options[:name] = field.name
+        options[:type] = field.type
         options[:value] = filter_hash['v']
         options[:label] = field.label
         options[:operator] = filter_hash['o']

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -57,6 +57,7 @@ module RailsAdmin
     end
 
     def ordered_filter_string
+      return if ordered_filters.blank?
       @ordered_filter_string ||= ordered_filters.map do |duplet|
         options = {index: duplet[0]}
         filter_for_field = duplet[1]
@@ -73,7 +74,7 @@ module RailsAdmin
         options[:label] = field.label
         options[:operator] = filter_hash['o']
         %{$.filters.append(#{options.to_json});}
-      end.join("\n").html_safe if ordered_filters
+      end.join("\n").html_safe
     end
 
     def options_for_field(field, filter_hash, options)

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -66,16 +66,16 @@ module RailsAdmin
           raise "#{filter_name} is not currently filterable; filterable fields are #{filterable_fields.map(&:name).join(', ')}"
         end
         case field.type
-          when :enum
-            options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).enum, filter_hash['v'])
-          when :has_and_belongs_to_many_association, :has_many_association
-            options[:multiple] = field.with(object: @abstract_model.model.new).multiple
-            options[:check_boxes] = field.with(object: @abstract_model.model.new).check_boxes
-            options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).filter_by, filter_hash['v']) unless options[:check_boxes]
-            options[:checkbox_values] = field.with(object: @abstract_model.model.new).filter_by if options[:check_boxes]
-            options[:applied_filters] = filter_hash['v'].map(&:to_i) if filter_hash['v'].is_a?(Array)
-          when :date, :datetime, :time
-            options[:datetimepicker_format] = field.parser.to_momentjs
+        when :enum
+          options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).enum, filter_hash['v'])
+        when :has_and_belongs_to_many_association, :has_many_association
+          options[:multi_select] = field.with(object: @abstract_model.model.new).multi_select
+          options[:check_boxes] = field.with(object: @abstract_model.model.new).check_boxes
+          options[:select_options] = options_for_select(field.with(object: @abstract_model.model.new).filter_by, filter_hash['v']) unless options[:check_boxes]
+          options[:checkbox_values] = field.with(object: @abstract_model.model.new).filter_by if options[:check_boxes]
+          options[:applied_filters] = filter_hash['v'].map(&:to_i) if filter_hash['v'].is_a?(Array)
+        when :date, :datetime, :time
+          options[:datetimepicker_format] = field.parser.to_momentjs
         end
         options[:label] = field.label
         options[:name] = field.name

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -28,6 +28,8 @@
           - field_options = case field.type
           - when :enum
             - options_for_select(field.with(object: @abstract_model.model.new).enum)
+          - when :has_and_belongs_to_many_association
+            - options_for_select(field.with(object: @abstract_model.model.new).filter_by)
           - else
             - ''
           %li

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -28,7 +28,7 @@
           - field_options = case field.type
           - when :enum
             - options_for_select(field.with(object: @abstract_model.model.new).enum)
-          - when :has_and_belongs_to_many_association
+          - when :has_and_belongs_to_many_association, :has_many_association
             - options_for_select(field.with(object: @abstract_model.model.new).filter_by)
           - else
             - ''

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -199,18 +199,18 @@ module RailsAdmin
 
         def get_duration
           case @operator
-            when 'between' then
-              between
-            when 'today' then
-              today
-            when 'yesterday' then
-              yesterday
-            when 'this_week' then
-              this_week
-            when 'last_week' then
-              last_week
-            else
-              default
+          when 'between' then
+            between
+          when 'today' then
+            today
+          when 'yesterday' then
+            yesterday
+          when 'this_week' then
+            this_week
+          when 'last_week' then
+            last_week
+          else
+            default
           end
         end
 

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -16,6 +16,7 @@ module RailsAdmin
       end
 
       alias_method :old_new, :new
+
       def new(m)
         m = m.constantize unless m.is_a?(Class)
         (am = old_new(m)).model && am.adapter ? am : nil
@@ -85,19 +86,19 @@ module RailsAdmin
     def each_associated_children(object)
       associations.each do |association|
         case association.type
-        when :has_one
-          if child = object.send(association.name)
-            yield(association, child)
-          end
-        when :has_many
-          object.send(association.name).each do |child| # rubocop:disable ShadowingOuterLocalVariable
-            yield(association, child)
-          end
+          when :has_one
+            if child = object.send(association.name)
+              yield(association, child)
+            end
+          when :has_many
+            object.send(association.name).each do |child| # rubocop:disable ShadowingOuterLocalVariable
+              yield(association, child)
+            end
         end
       end
     end
 
-  private
+    private
 
     def initialize_active_record
       @adapter = :active_record
@@ -129,7 +130,7 @@ module RailsAdmin
           build_statement_for_type_generic
       end
 
-    protected
+      protected
 
       def get_filtering_duration
         FilteringDuration.new(@operator, @value).get_duration
@@ -138,10 +139,10 @@ module RailsAdmin
       def build_statement_for_type_generic
         build_statement_for_type || begin
           case @type
-          when :date
-            build_statement_for_date
-          when :datetime, :timestamp
-            build_statement_for_datetime_or_timestamp
+            when :date
+              build_statement_for_date
+            when :datetime, :timestamp
+              build_statement_for_datetime_or_timestamp
           end
         end
       end
@@ -152,21 +153,21 @@ module RailsAdmin
 
       def build_statement_for_integer_decimal_or_float
         case @value
-        when Array then
-          val, range_begin, range_end = *@value.collect do |v|
-            next unless v.to_i.to_s == v || v.to_f.to_s == v
-            @type == :integer ? v.to_i : v.to_f
-          end
-          case @operator
-          when 'between'
-            range_filter(range_begin, range_end)
+          when Array then
+            val, range_begin, range_end = *@value.collect do |v|
+              next unless v.to_i.to_s == v || v.to_f.to_s == v
+              @type == :integer ? v.to_i : v.to_f
+            end
+            case @operator
+              when 'between'
+                range_filter(range_begin, range_end)
+              else
+                column_for_value(val) if val
+            end
           else
-            column_for_value(val) if val
-          end
-        else
-          if @value.to_i.to_s == @value || @value.to_f.to_s == @value
-            @type == :integer ? column_for_value(@value.to_i) : column_for_value(@value.to_f)
-          end
+            if @value.to_i.to_s == @value || @value.to_f.to_s == @value
+              @type == :integer ? column_for_value(@value.to_i) : column_for_value(@value.to_f)
+            end
         end
       end
 
@@ -200,12 +201,18 @@ module RailsAdmin
 
         def get_duration
           case @operator
-          when 'between'   then between
-          when 'today'     then today
-          when 'yesterday' then yesterday
-          when 'this_week' then this_week
-          when 'last_week' then last_week
-          else default
+            when 'between' then
+              between
+            when 'today' then
+              today
+            when 'yesterday' then
+              yesterday
+            when 'this_week' then
+              this_week
+            when 'last_week' then
+              last_week
+            else
+              default
           end
         end
 
@@ -234,7 +241,7 @@ module RailsAdmin
           [default_date, default_date]
         end
 
-      private
+        private
 
         def default_date
           Array.wrap(@value).first

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -100,13 +100,14 @@ module RailsAdmin
         def add(field, value, operator)
           field.searchable_columns.flatten.each do |column_infos|
             type = column_infos[:type]
-			value,type = 
-			  if field.many_field?
-              	field.parse_value(value), type, :has_and_belongs_to_many_association
+            value =
+              if field.many_field?
+                type = :has_and_belongs_to_many_association
+                field.parse_value(value)
               elsif value.is_a?(Array)
-              	value.map { |v| field.parse_value(v) },nil
+                value.map { |v| field.parse_value(v) }
               else
-              	field.parse_value(value), nil
+                field.parse_value(value)
               end
             statement, value1, value2 = StatementBuilder.new(column_infos[:column], type, value, operator).to_statement
             @statements << statement if statement.present?
@@ -200,13 +201,20 @@ module RailsAdmin
 
         def build_statement_for_type
           case @type
-          when :boolean                             then build_statement_for_boolean
-          when :integer, :decimal, :float           then build_statement_for_integer_decimal_or_float
-          when :string, :text                       then build_statement_for_string_or_text
-          when :enum                                then build_statement_for_enum
-          when :belongs_to_association              then build_statement_for_belongs_to_association
-          when :has_many_association                then build_statement_for_has_many_association
-          when :has_and_belongs_to_many_association then build_statement_for_has_and_belongs_to_many_association
+          when :boolean then
+            build_statement_for_boolean
+          when :integer, :decimal, :float then
+            build_statement_for_integer_decimal_or_float
+          when :string, :text then
+            build_statement_for_string_or_text
+          when :enum then
+            build_statement_for_enum
+          when :belongs_to_association then
+            build_statement_for_belongs_to_association
+          when :has_many_association then
+            build_statement_for_has_many_association
+          when :has_and_belongs_to_many_association then
+            build_statement_for_has_and_belongs_to_many_association
           end
         end
 
@@ -225,11 +233,11 @@ module RailsAdmin
         end
 
         def build_statement_for_has_many_association
-          build_statement_for_enum
+          in_array_statement
         end
 
         def build_statement_for_has_and_belongs_to_many_association
-          build_statement_for_enum
+          in_array_statement
         end
 
         def build_statement_for_string_or_text
@@ -257,6 +265,10 @@ module RailsAdmin
         end
 
         def build_statement_for_enum
+          in_array_statement
+        end
+
+        def in_array_statement
           return if @value.blank?
           ["(#{@column} IN (?))", Array.wrap(@value)]
         end

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -66,6 +66,18 @@ module RailsAdmin
           !!searchable
         end
 
+        register_instance_option :filter_by do
+          bindings[:object].respond_to?(:filter_by) ? (searchable && bindings[:object].send(:filter_by)) : []
+        end
+
+        register_instance_option :multi_select do
+          false
+        end
+
+        register_instance_option :check_boxes do
+          false
+        end
+
         # Reader for the association's child model's configuration
         def associated_model_config
           @associated_model_config ||= RailsAdmin.config(association.klass)

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -40,6 +40,10 @@ module RailsAdmin
           properties.blank?
         end
 
+        def many_field?
+          is_a?(RailsAdmin::Config::Fields::Types::HasAndBelongsToManyAssociation) || is_a?(RailsAdmin::Config::Fields::Types::HasManyAssociation)
+        end
+
         register_instance_option :column_width do
           nil
         end

--- a/lib/rails_admin/config/fields/factories/association.rb
+++ b/lib/rails_admin/config/fields/factories/association.rb
@@ -3,7 +3,7 @@ require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/belongs_to_association'
 
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
-  if association = parent.abstract_model.associations.detect { |a| a.foreign_key == properties.name && [:belongs_to, :has_and_belongs_to_many].include?(a.type) }
+  if association = parent.abstract_model.associations.detect { |a| a.foreign_key == properties.name && [:belongs_to, :has_many, :has_and_belongs_to_many].include?(a.type) }
     field = RailsAdmin::Config::Fields::Types.load("#{association.polymorphic? ? :polymorphic : association.type}_association").new(parent, association.name, association)
     fields << field
 

--- a/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
@@ -7,6 +7,15 @@ module RailsAdmin
         class HasAndBelongsToManyAssociation < RailsAdmin::Config::Fields::Types::HasManyAssociation
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :multiple do
+            bindings[:object].respond_to?(:multiple) ? bindings[:object].send(:multiple) : false
+          end
+
+          def parse_value(value)
+            value
+          end
+
         end
       end
     end

--- a/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
@@ -5,17 +5,10 @@ module RailsAdmin
     module Fields
       module Types
         class HasAndBelongsToManyAssociation < RailsAdmin::Config::Fields::Types::HasManyAssociation
-          # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
-
-          register_instance_option :multiple do
-            bindings[:object].respond_to?(:multiple) ? bindings[:object].send(:multiple) : false
-          end
-
           def parse_value(value)
             value
           end
-
         end
       end
     end

--- a/lib/rails_admin/config/fields/types/has_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_many_association.rb
@@ -21,6 +21,14 @@ module RailsAdmin
             true
           end
 
+          register_instance_option :filter_by do
+            bindings[:object].respond_to?(:filter_by) ? bindings[:object].send(:filter_by) : []
+          end
+
+          register_instance_option :check_boxes do
+            bindings[:object].respond_to?(:check_boxes) ? bindings[:object].send(:check_boxes) : false
+          end
+
           def method_name
             nested_form ? "#{super}_attributes".to_sym : "#{super.to_s.singularize}_ids".to_sym  # name_ids
           end

--- a/lib/rails_admin/config/fields/types/has_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_many_association.rb
@@ -5,14 +5,11 @@ module RailsAdmin
     module Fields
       module Types
         class HasManyAssociation < RailsAdmin::Config::Fields::Association
-          # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
-
           register_instance_option :partial do
             nested_form ? :form_nested_many : :form_filtering_multiselect
           end
 
-          # orderable associated objects
           register_instance_option :orderable do
             false
           end
@@ -21,8 +18,12 @@ module RailsAdmin
             true
           end
 
+          register_instance_option :multi_select do
+            bindings[:object].respond_to?(:multi_select) ? bindings[:object].send(:multi_select) : false
+          end
+
           register_instance_option :filter_by do
-            bindings[:object].respond_to?(:filter_by) ? bindings[:object].send(:filter_by) : []
+            bindings[:object].respond_to?(:filter_by) ? (searchable && bindings[:object].send(:filter_by)) : []
           end
 
           register_instance_option :check_boxes do

--- a/lib/rails_admin/config/fields/types/has_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_many_association.rb
@@ -22,10 +22,6 @@ module RailsAdmin
             bindings[:object].respond_to?(:multi_select) ? bindings[:object].send(:multi_select) : false
           end
 
-          register_instance_option :filter_by do
-            bindings[:object].respond_to?(:filter_by) ? (searchable && bindings[:object].send(:filter_by)) : []
-          end
-
           register_instance_option :check_boxes do
             bindings[:object].respond_to?(:check_boxes) ? bindings[:object].send(:check_boxes) : false
           end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -603,13 +603,14 @@ describe 'RailsAdmin Basic List', type: :request do
       before do
         RailsAdmin.config do |config|
           config.model Player do
+            field :name
+            field :team, :belongs_to_association do
+              searchable [:name]
+              filterable true
+            end
+
             list do
               filters [:team]
-              field :name
-              field :team, :belongs_to_association do
-                searchable [:name]
-                filterable true
-              end
             end
           end
         end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -569,21 +569,21 @@ describe 'RailsAdmin Basic List', type: :request do
   end
 
   describe 'list filter for belongs to  association', js: true do
-    let!(:players) do
-      [
-        FactoryGirl.create(:player, name: 'Harry Hipster', team: teams.first),
-        FactoryGirl.create(:player, name: 'Micky Mighty', team: teams[1]),
-        FactoryGirl.create(:player, name: 'Colby James', team: teams[2]),
-        FactoryGirl.create(:player, name: 'Johnny Jangle', team: teams.last),
-      ]
-    end
-
     let!(:teams) do
       [
         FactoryGirl.create(:team, name: 'Red Devils', color: 'red'),
         FactoryGirl.create(:team, name: 'Red Rockets', color: 'red'),
         FactoryGirl.create(:team, name: 'White Walters', color: 'white'),
         FactoryGirl.create(:team, name: 'Black Magics', color: 'black'),
+      ]
+    end
+
+    let!(:players) do
+      [
+        FactoryGirl.create(:player, name: 'Harry Hipster', team: teams.first),
+        FactoryGirl.create(:player, name: 'Micky Mighty', team: teams[1]),
+        FactoryGirl.create(:player, name: 'Colby James', team: teams[2]),
+        FactoryGirl.create(:player, name: 'Johnny Jangle', team: teams.last),
       ]
     end
 
@@ -608,7 +608,7 @@ describe 'RailsAdmin Basic List', type: :request do
         visit index_path(model_name: 'player')
 
         teams.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
 
         within('span#filters_box') do
@@ -617,11 +617,11 @@ describe 'RailsAdmin Basic List', type: :request do
         click_button('Refresh')
 
         teams.select { |t| t.name =~ /Red/ }.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
 
         teams.reject { |t| t.name =~ /Red/ }.each do |team|
-          is_expected.to_not have_selector("td[title='#{team.name}']")
+          is_expected.to_not have_selector(list_item_with_title(team.name))
         end
       end
     end
@@ -650,7 +650,7 @@ describe 'RailsAdmin Basic List', type: :request do
       it 'allows user to choose from select list to search associated field' do
         visit index_path(model_name: 'player')
         teams.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
 
         within('span#filters_box') do
@@ -660,11 +660,11 @@ describe 'RailsAdmin Basic List', type: :request do
         click_button('Refresh')
 
         teams.select { |t| t.name =~ /Red Devils/ }.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
 
         teams.reject { |t| t.name =~ /Red Devils/ }.each do |team|
-          is_expected.to_not have_selector("td[title='#{team.name}']")
+          is_expected.to_not have_selector(list_item_with_title(team.name))
         end
       end
     end
@@ -728,7 +728,7 @@ describe 'RailsAdmin Basic List', type: :request do
         click_button('Refresh')
 
         teams.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
       end
 
@@ -746,11 +746,11 @@ describe 'RailsAdmin Basic List', type: :request do
         end
 
         larry.teams.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
 
         (teams - larry.teams).each do |team|
-          is_expected.to_not have_selector("td[title='#{team.name}']")
+          is_expected.to_not have_selector(list_item_with_title(team.name))
         end
       end
     end
@@ -814,7 +814,7 @@ describe 'RailsAdmin Basic List', type: :request do
         click_button('Refresh')
 
         teams.each do |team|
-          is_expected.to have_selector("td[title='#{team.name}']")
+          is_expected.to have_selector(list_item_with_title(team.name))
         end
       end
 
@@ -831,10 +831,10 @@ describe 'RailsAdmin Basic List', type: :request do
           expect(find(checkbox_filter_selector('players', harry_hipster)).checked?).to be_truthy
         end
 
-        is_expected.to have_selector("td[title='#{harry_hipster.team.name}']")
+        is_expected.to have_selector(list_item_with_title(harry_hipster.team.name))
 
         (teams - [harry_hipster.team]).each do |team|
-          is_expected.to_not have_selector("td[title='#{team.name}']")
+          is_expected.to_not have_selector(list_item_with_title(team.name))
         end
       end
     end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -2,18 +2,6 @@
 
 require 'spec_helper'
 
-def checkbox_filter_selector(association_name, model)
-  "input[name='f[#{association_name}][1][v][]'][value='#{model.id}']"
-end
-
-def text_filter_selector(association_name)
-  "input[name='f[#{association_name}][1][v]'][type='text']"
-end
-
-def select_filter_selector(association_name)
-  "select[name='f[#{association_name}][1][v]']"
-end
-
 describe 'RailsAdmin Basic List', type: :request do
   subject { page }
 

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -2,6 +2,10 @@
 
 require 'spec_helper'
 
+def checkbox_selector(association_name, model)
+  "input[name='f[#{association_name}][1][v][]'][value='#{model.id}']"
+end
+
 describe 'RailsAdmin Basic List', type: :request do
   subject { page }
 
@@ -560,6 +564,176 @@ describe 'RailsAdmin Basic List', type: :request do
           expect(find('#scope_selector li:nth-child(3)')).to have_content('White')
           expect(find('#scope_selector li:last')).to have_content('White')
           expect(find('#scope_selector li.active')).to have_content('any')
+        end
+      end
+    end
+  end
+
+  describe 'filter list for many to many association', js: true do
+    let!(:teams) do
+      [
+        FactoryGirl.create(:team, name: 'Red Devils', color: 'red'),
+        FactoryGirl.create(:team, name: 'Red Rockets', color: 'red'),
+        FactoryGirl.create(:team, name: 'White Walters', color: 'white'),
+        FactoryGirl.create(:team, name: 'Black Magics', color: 'black'),
+      ]
+    end
+
+    let!(:fans) do
+      [
+        FactoryGirl.create(:fan, name: 'Larry', teams: [teams.first]),
+        FactoryGirl.create(:fan, name: 'Moe', teams: teams),
+        FactoryGirl.create(:fan, name: 'Curly', teams: teams.slice(0, 2)),
+        FactoryGirl.create(:fan, name: 'Nicola Tesla', teams: [teams.last]),
+      ]
+    end
+
+    before do
+      RailsAdmin.config do |config|
+        config.model Team do
+          field :name
+          field :fans, :has_and_belongs_to_many_association do
+            searchable [:id]
+            filterable true
+
+            filter_by do
+              Fan.all.map { |c| [c.name, c.id] }
+            end
+
+            multi_select do
+              true
+            end
+            check_boxes do
+              true
+            end
+          end
+
+          list do
+            filters [:fans]
+          end
+        end
+      end
+    end
+
+    describe 'filter_by multi_select check_boxes' do
+      it 'check all associated checkboxes returns all objects' do
+        visit index_path(model_name: 'team')
+
+        within('span#filters_box') do
+          fans.each do |fan|
+            find(checkbox_selector('fans', fan)).set(true)
+          end
+        end
+        click_button('Refresh')
+
+        teams.each do |team|
+          is_expected.to have_selector("td[title='#{team.name}']")
+        end
+      end
+
+      it 'check one associated checkbox return only that objects that are associated' do
+        visit index_path(model_name: 'team')
+
+        larry = fans.detect { |fan| fan.name == 'Larry' }
+        within('span#filters_box') do
+          find(checkbox_selector('fans', larry)).set(true)
+        end
+        click_button('Refresh')
+
+        within('span#filters_box') do
+          expect(find(checkbox_selector('fans', larry)).checked?).to be_truthy
+        end
+
+        larry.teams.each do |team|
+          is_expected.to have_selector("td[title='#{team.name}']")
+        end
+
+        (teams - larry.teams).each do |team|
+          is_expected.to_not have_selector("td[title='#{team.name}']")
+        end
+      end
+    end
+  end
+
+  describe 'filter list for one to many association', js: true do
+    let!(:teams) do
+      [
+        FactoryGirl.create(:team, name: 'Red Devils', color: 'red'),
+        FactoryGirl.create(:team, name: 'Red Rockets', color: 'red'),
+        FactoryGirl.create(:team, name: 'White Walters', color: 'white'),
+        FactoryGirl.create(:team, name: 'Black Magics', color: 'black'),
+      ]
+    end
+
+    let!(:players) do
+      [
+        FactoryGirl.create(:player, name: 'Harry Hipster', team: teams.first),
+        FactoryGirl.create(:player, name: 'Micky Mighty', team: teams[1]),
+        FactoryGirl.create(:player, name: 'Colby James', team: teams[2]),
+        FactoryGirl.create(:player, name: 'Johnny Jangle', team: teams.last),
+      ]
+    end
+
+    before do
+      RailsAdmin.config do |config|
+        config.model Team do
+          field :name
+          field :players, :has_many_association do
+            searchable [:id]
+            filterable true
+
+            filter_by do
+              Player.all.map { |c| [c.name, c.id] }
+            end
+
+            multi_select do
+              true
+            end
+            check_boxes do
+              true
+            end
+          end
+
+          list do
+            filters [:players]
+          end
+        end
+      end
+    end
+
+    describe 'filter_by multi_select check_boxes' do
+      it 'check all associated checkboxes returns all objects' do
+        visit index_path(model_name: 'team')
+
+        within('span#filters_box') do
+          players.each do |player|
+            find(checkbox_selector('players', player)).set(true)
+          end
+        end
+        click_button('Refresh')
+
+        teams.each do |team|
+          is_expected.to have_selector("td[title='#{team.name}']")
+        end
+      end
+
+      it 'check one associated checkbox return only that objects that are associated' do
+        visit index_path(model_name: 'team')
+
+        harry_hipster = players.detect { |player| player.name == 'Harry Hipster' }
+        within('span#filters_box') do
+          find(checkbox_selector('players', harry_hipster)).set(true)
+        end
+        click_button('Refresh')
+
+        within('span#filters_box') do
+          expect(find(checkbox_selector('players', harry_hipster)).checked?).to be_truthy
+        end
+
+        is_expected.to have_selector("td[title='#{harry_hipster.team.name}']")
+
+        (teams - [harry_hipster.team]).each do |team|
+          is_expected.to_not have_selector("td[title='#{team.name}']")
         end
       end
     end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -657,7 +657,11 @@ describe 'RailsAdmin Basic List', type: :request do
           team_select = find(select_filter_selector('team'))
           team_select.select('Red Devils')
         end
+        unfiltered_url =  page.current_url
+
         click_button('Refresh')
+
+        expect(unfiltered_url).to_not eq page.current_url
 
         teams.select { |t| t.name =~ /Red Devils/ }.each do |team|
           is_expected.to have_selector(list_item_with_title(team.name))
@@ -725,7 +729,11 @@ describe 'RailsAdmin Basic List', type: :request do
             find(checkbox_filter_selector('fans', fan)).set(true)
           end
         end
+        unfiltered_url =  page.current_url
+
         click_button('Refresh')
+
+        expect(unfiltered_url).to_not eq page.current_url
 
         teams.each do |team|
           is_expected.to have_selector(list_item_with_title(team.name))
@@ -811,7 +819,11 @@ describe 'RailsAdmin Basic List', type: :request do
             find(checkbox_filter_selector('players', player)).set(true)
           end
         end
+        unfiltered_url =  page.current_url
+
         click_button('Refresh')
+
+        expect(unfiltered_url).to_not eq page.current_url
 
         teams.each do |team|
           is_expected.to have_selector(list_item_with_title(team.name))

--- a/spec/rails_admin/adapters/active_record/association_spec.rb
+++ b/spec/rails_admin/adapters/active_record/association_spec.rb
@@ -54,7 +54,8 @@ describe 'RailsAdmin::Adapters::ActiveRecord::Association', active_record: true 
 
   it 'list associations types in supported [:belongs_to, :has_and_belongs_to_many, :has_many, :has_one]' do
     # ActiveRecord 4.1 converts has_and_belongs_to_many association to has_many
-    expect((@post.associations + @blog.associations + @user.associations).collect(&:type).uniq.collect(&:to_s)).to include(*%w(belongs_to has_many has_one))
+    # ActiveRecord 4.2 does no such conversion
+    expect((@post.associations + @blog.associations + @user.associations).collect(&:type).uniq.collect(&:to_s)).to include(*%w(belongs_to has_many has_one has_and_belongs_to_many))
   end
 
   describe 'belongs_to association' do

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -236,6 +236,16 @@ describe RailsAdmin::Config::Fields::Base do
         end
         expect(RailsAdmin.config(Team).fields.detect { |f| f.name == :division }.searchable_columns).to eq([{column: 'leagues.name', type: :string}])
       end
+
+      it 'searches all columns on associated model' do
+        RailsAdmin.config(Team) do
+          field :fans do
+            searchable :all
+          end
+        end
+        expect(RailsAdmin.config(Team).fields.detect { |f| f.name == :fans }.searchable_columns.collect { |c| c[:column] }).to eq(%w(fans.id fans.created_at fans.updated_at fans.name fans.teams))
+      end
+
     end
 
     describe 'for basic type fields' do

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -245,7 +245,6 @@ describe RailsAdmin::Config::Fields::Base do
         end
         expect(RailsAdmin.config(Team).fields.detect { |f| f.name == :fans }.searchable_columns.collect { |c| c[:column] }).to eq(%w(fans.id fans.created_at fans.updated_at fans.name fans.teams))
       end
-
     end
 
     describe 'for basic type fields' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,11 @@ Devise.setup do |config|
 end
 
 require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, inspector: 'open')
+end
+Capybara.javascript_driver = :poltergeist_debug
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
@@ -61,9 +65,7 @@ RSpec.configure do |config|
 
   config.include RSpec::Matchers
   config.include RailsAdmin::Engine.routes.url_helpers
-
   config.include Warden::Test::Helpers
-
   config.include Capybara::DSL, type: :request
 
   config.before do |example|
@@ -88,4 +90,8 @@ RSpec.configure do |config|
       config.filter_run_excluding orm => true
     end
   end
+end
+
+def debugit(*args, &block)
+  it(*args, {driver: :poltergeist_debug, inspector: true}, &block)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ require 'factories'
 require 'policies'
 require 'database_cleaner'
 require "orm/#{CI_ORM}"
+require 'support/filter_box_selectors'
 
 Dir[File.expand_path('../shared_examples/**/*.rb', __FILE__)].each { |f| require f }
 
@@ -67,6 +68,7 @@ RSpec.configure do |config|
   config.include RailsAdmin::Engine.routes.url_helpers
   config.include Warden::Test::Helpers
   config.include Capybara::DSL, type: :request
+  config.include FilterBoxSelectors
 
   config.before do |example|
     DatabaseCleaner.strategy = (CI_ORM == :mongoid || example.metadata[:js]) ? :truncation : :transaction

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,8 @@ require 'factories'
 require 'policies'
 require 'database_cleaner'
 require "orm/#{CI_ORM}"
-require 'support/filter_box_selectors'
 
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 Dir[File.expand_path('../shared_examples/**/*.rb', __FILE__)].each { |f| require f }
 
 ActionMailer::Base.delivery_method = :test
@@ -52,13 +52,6 @@ Devise.setup do |config|
   config.stretches = 0
 end
 
-require 'capybara/poltergeist'
-
-Capybara.register_driver :poltergeist_debug do |app|
-  Capybara::Poltergeist::Driver.new(app, inspector: 'open')
-end
-Capybara.javascript_driver = :poltergeist_debug
-
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
@@ -69,6 +62,8 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include Capybara::DSL, type: :request
   config.include FilterBoxSelectors
+  config.include ListSelectors
+  config.include PoltergeistHelper
 
   config.before do |example|
     DatabaseCleaner.strategy = (CI_ORM == :mongoid || example.metadata[:js]) ? :truncation : :transaction
@@ -92,8 +87,4 @@ RSpec.configure do |config|
       config.filter_run_excluding orm => true
     end
   end
-end
-
-def debugit(*args, &block)
-  it(*args, {driver: :poltergeist_debug, inspector: true}, &block)
 end

--- a/spec/support/filter_box_selectors.rb
+++ b/spec/support/filter_box_selectors.rb
@@ -1,0 +1,13 @@
+module FilterBoxSelectors
+  def checkbox_filter_selector(association_name, model)
+    "input[name='f[#{association_name}][1][v][]'][value='#{model.id}']"
+  end
+
+  def text_filter_selector(association_name)
+    "input[name='f[#{association_name}][1][v]'][type='text']"
+  end
+
+  def select_filter_selector(association_name)
+    "select[name='f[#{association_name}][1][v]']"
+  end
+end

--- a/spec/support/list_selectors.rb
+++ b/spec/support/list_selectors.rb
@@ -1,8 +1,6 @@
 module ListSelectors
-
   # match td title attribute
   def list_item_with_title(title)
     "td[title='#{title}']"
   end
-
 end

--- a/spec/support/list_selectors.rb
+++ b/spec/support/list_selectors.rb
@@ -1,0 +1,8 @@
+module ListSelectors
+
+  # match td title attribute
+  def list_item_with_title(title)
+    "td[title='#{title}']"
+  end
+
+end

--- a/spec/support/poltergeist_helper.rb
+++ b/spec/support/poltergeist_helper.rb
@@ -1,0 +1,16 @@
+require 'capybara/poltergeist'
+
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, inspector: 'open')
+end
+
+Capybara.javascript_driver = :poltergeist
+
+module PoltergeistHelper
+  # Poltergeist debug version of RSpec's it "Do something" block.
+  # Usage: Rename  it block to call debugit
+  # Use page page.driver.debug where wish to stop
+  def debugit(*args, &block)
+    it(*args, {driver: :poltergeist_debug, inspector: true}, &block)
+  end
+end


### PR DESCRIPTION
Proposed expansion of the field DSL to allow better association filtering.
Expanded and refactored filter box JavaScript. 
  DSL Example:
 See [rails_admin_basic_list_spec](https://github.com/impurist/rails_admin/blob/association-filters/spec/integration/basic/list/rails_admin_basic_list_spec.rb) for more examples.
```
config.model Team do
        field :name
        field :fans, :has_and_belongs_to_many_association do
        searchable [:id]
        filterable true

        filter_by do
           Fan.all.map { |c| [c.name, c.id] }
        end

        multi_select do
            true
        end

        check_boxes do
           true
        end
    end

    list do
       filters [:fans]
    end
end
```
I value any comments, suggestions, criticisms or indeed help to get these proposed changes right. and accepted.
