### PR TITLE
Config option to change default csv encoding

### DIFF
--- a/app/views/rails_admin/main/export.html.haml
+++ b/app/views/rails_admin/main/export.html.haml
@@ -56,11 +56,11 @@
       %i.icon-chevron-down
       = t('admin.export.options_for', name: 'csv')
     .form-group.control-group
-      - guessed_encoding = @abstract_model.encoding
+      - guessed_encoding = Encoding.name_list.include?(RailsAdmin.config.csv_default_encoding) ? RailsAdmin.config.csv_default_encoding : @abstract_model.encoding
       %label.col-sm-2.control-label{for: "csv_options_encoding_to"}= t('admin.export.csv.encoding_to')
       .col-sm-10.controls
         -# from http://books.google.com/support/partner/bin/answer.py?answer=30990 :
-        = select_tag 'csv_options[encoding_to]', options_for_select(Encoding.name_list.sort), include_blank: true, placeholder: t('admin.misc.search'), :'data-enumeration' => true
+        = select_tag 'csv_options[encoding_to]', options_for_select(Encoding.name_list.sort, guessed_encoding), include_blank: true, placeholder: t('admin.misc.search'), :'data-enumeration' => true
         %p.help-block= t('admin.export.csv.encoding_to_help', name: guessed_encoding)
 
     .form-group.control-group

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -78,6 +78,9 @@ module RailsAdmin
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
 
+      # default encoding used in csv export
+      attr_accessor :csv_default_encoding
+
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #


### PR DESCRIPTION
Option to configure CSV export encoding. 

Currently default is Rails default, which is usually UTF-8. That's usually fine, but Windows Excel doesn't support it and list of available encodings is very long so it's not too easy to find correct Windows-xyz encoding when you are doing CSV export on Windows machines. So I added config option (csv_default_encoding) to change default encoding used in export menu.