### PR TITLE
try to_s, fix 'no implicit conversion of Fixnum into String'

### DIFF
--- a/lib/rails_admin/config/fields/types/serialized.rb
+++ b/lib/rails_admin/config/fields/types/serialized.rb
@@ -13,7 +13,7 @@ module RailsAdmin
           end
 
           def parse_value(value)
-            value.present? ? (RailsAdmin.yaml_load(value) || nil) : nil
+            value.present? ? (RailsAdmin.yaml_load(value.try(:to_s)) || nil) : nil
           end
 
           def parse_input(params)


### PR DESCRIPTION
When i search telphone number, sometimes got 'no implicit conversion of Fixnum into String' error.

path/bundle/ruby/2.3.0/gems/rails_admin-1.1.0/lib/rails_admin.rb:49:in 'yaml_load'
path/bundle/ruby/2.3.0/gems/rails_admin-1.1.0/lib/rails_admin/config/fields/types/serialized.rb:16:in 'parse_value'
path/bundle/ruby/2.3.0/gems/rails_admin-1.1.0/lib/rails_admin/adapters/active_record.rb:106:in 'block in add'