### PR TITLE
Load models from eager_load, not autoload_paths

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -323,7 +323,7 @@ module RailsAdmin
         included_models.collect(&:to_s).presence || begin
           @@system_models ||= # memoization for tests
             ([Rails.application] + Rails::Engine.subclasses.collect(&:instance)).flat_map do |app|
-              (app.paths['app/models'].to_a + app.config.autoload_paths).collect do |load_path|
+              (app.paths['app/models'].to_a + app.paths.eager_load).collect do |load_path|
                 Dir.glob(app.root.join(load_path)).collect do |load_dir|
                   Dir.glob(load_dir + '/**/*.rb').collect do |filename|
                     # app/models/module/class.rb => module/class.rb => module/class => Module::Class

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -20,7 +20,7 @@ module DummyApp
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.eager_load_paths.reject! { |p| p =~ %r{/app/(\w+)$} && !%w(controllers helpers views).push(CI_ORM).include?(Regexp.last_match[1]) }
-    config.autoload_paths += %W(#{config.root}/app/#{CI_ORM} #{config.root}/app/#{CI_ORM}/concerns)
+    config.autoload_paths += %W(#{config.root}/app/#{CI_ORM} #{config.root}/app/#{CI_ORM}/concerns #{config.root}/lib)
     config.i18n.load_path += Dir[Rails.root.join('app', 'locales', '*.{rb,yml}').to_s]
     config.active_record.raise_in_transactional_callbacks = true if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR == 2 && CI_ORM == :active_record
     config.active_record.time_zone_aware_types = [:datetime, :time] if Rails::VERSION::MAJOR >= 5 && CI_ORM == :active_record

--- a/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
+++ b/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
@@ -1,4 +1,4 @@
 module DoesNotLoadAutoloadPathsNotInEagerLoad
-  fail 'This file is in app.paths.autoload but not app.paths.eager_load and ' \
-       ' should not be autoloaded by rails_admin'
+  raise 'This file is in app.paths.autoload but not app.paths.eager_load and ' \
+        ' should not be autoloaded by rails_admin'
 end

--- a/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
+++ b/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
@@ -1,0 +1,4 @@
+module DoesNotLoadAutoloadPathsNotInEagerLoad
+  fail 'This file is in app.paths.autoload but not app.paths.eager_load and ' \
+       ' should not be autoloaded by rails_admin'
+end


### PR DESCRIPTION
If something is in `autoload_paths`, it doesn't mean it can or should *always* be loaded. Rails explicitly makes this distinction with `eager_load`.

E.g. if I'm developing a Rails engine, I might want to add `lib` to autoload paths (to ease the development of the engine), but that doesn't mean I want to eagerly load ruby files in `lib/generators/templates`!

Resolves #2770