### PR TITLE
Return status code 200 when destroying a record from the index page fails

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -63,6 +63,7 @@ module RailsAdmin
     rescue_from RailsAdmin::ObjectNotFound do
       flash[:error] = I18n.t('admin.flash.object_not_found', model: @model_name, id: params[:id])
       params[:action] = 'index'
+      @status_code = :not_found
       index
     end
 

--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -70,6 +70,7 @@ module RailsAdmin
     rescue_from RailsAdmin::ModelNotFound do
       flash[:error] = I18n.t('admin.flash.model_not_found', model: @model_name)
       params[:action] = 'dashboard'
+      @status_code = :not_found
       dashboard
     end
   end

--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -30,7 +30,7 @@ module RailsAdmin
                 @most_recent_created[t.model.name] = t.model.last.try(:created_at)
               end
             end
-            render @action.template_name, status: (flash[:error].present? ? :not_found : 200)
+            render @action.template_name, status: @status_code || :ok
           end
         end
 

--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -41,7 +41,7 @@ module RailsAdmin
 
             respond_to do |format|
               format.html do
-                render @action.template_name, status: (flash[:error].present? ? :not_found : 200)
+                render @action.template_name, status: @status_code || :ok
               end
 
               format.json do

--- a/spec/integration/basic/destroy/rails_admin_basic_destroy_spec.rb
+++ b/spec/integration/basic/destroy/rails_admin_basic_destroy_spec.rb
@@ -39,6 +39,10 @@ describe 'RailsAdmin Basic Destroy', type: :request do
     it 'shows error message' do
       is_expected.to have_content('Player failed to be deleted')
     end
+
+    it 'returns status code 200' do
+      expect(page.status_code).to eq(200)
+    end
   end
 
   describe 'destroy' do
@@ -86,6 +90,22 @@ describe 'RailsAdmin Basic Destroy', type: :request do
       click_button "Yes, I'm sure"
 
       expect(URI.parse(page.current_url).path).to eq(show_path(model_name: 'player', id: @player.id))
+    end
+  end
+
+  describe 'destroy from index page' do
+    it 'returns status code 200' do
+      if Rails.version >= '5.0'
+        allow_any_instance_of(Player).to receive(:destroy_hook) { throw :abort }
+      else
+        allow_any_instance_of(Player).to receive(:destroy_hook).and_return false
+      end
+      @player = FactoryGirl.create :player
+      visit index_path(model_name: 'player')
+      click_link 'Delete'
+      click_button "Yes, I'm sure"
+
+      expect(page.status_code).to eq(200)
     end
   end
 end


### PR DESCRIPTION
This PR closes issue #2775.

It changes how the index and the dashboard actions decide which status code to return. Instead of relying on `flash[:error]` to render status code 404, the new instance variable `@status_code` is used.