### PR TITLE
fix application_helper#bulk_menu for overriding abstract_model

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -160,7 +160,7 @@ module RailsAdmin
           content_tag(:ul, class: 'dropdown-menu', style: 'left:auto; right:0;') do
             actions.collect do |action|
               content_tag :li do
-                link_to wording_for(:bulk_link, action), '#', onclick: "jQuery('#bulk_action').val('#{action.action_name}'); jQuery('#bulk_form').submit(); return false;"
+                link_to wording_for(:bulk_link, action, abstract_model), '#', onclick: "jQuery('#bulk_action').val('#{action.action_name}'); jQuery('#bulk_form').submit(); return false;"
               end
             end.join.html_safe
           end

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -355,12 +355,25 @@ describe RailsAdmin::ApplicationHelper, type: :helper do
             end
           end
         end
-        @action = RailsAdmin::Config::Actions.find :index
-        result = helper.bulk_menu(RailsAdmin::AbstractModel.new(Team))
-        expect(result).to match('zorg_action')
-        expect(result).to match('blub')
+        en = {admin: {actions: {
+          zorg: {bulk_link: 'Zorg all these %{model_label_plural}'},
+          blub: {bulk_link: 'Blub all these %{model_label_plural}'},
+        }}}
+        I18n.backend.store_translations(:en, en)
 
-        expect(helper.bulk_menu(RailsAdmin::AbstractModel.new(Player))).not_to match('blub')
+        @abstract_model = RailsAdmin::AbstractModel.new(Team)
+        result = helper.bulk_menu
+
+        expect(result).to match('zorg_action')
+        expect(result).to match('Zorg all these Teams')
+        expect(result).to match('blub')
+        expect(result).to match('Blub all these Teams')
+
+        result_2 = helper.bulk_menu(RailsAdmin::AbstractModel.new(Player))
+        expect(result_2).to match('zorg_action')
+        expect(result_2).to match('Zorg all these Players')
+        expect(result_2).not_to match('blub')
+        expect(result_2).not_to match('Blub all these Players')
       end
     end
 


### PR DESCRIPTION
When using the helper method `bulk_menu` for a model that is not the current
`@abstract_model` the helper incorrectly gets the wording for the instance
variable instead of passing the passed variable through.