### PR TITLE
Use ActiveSupport.on_load to correctly re-open ActiveRecord::Base.

### DIFF
--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -1,4 +1,4 @@
-if defined?(::ActiveRecord)
+ActiveSupport.on_load(:active_record) do
   module ActiveRecord
     class Base
       def self.rails_admin(&block)


### PR DESCRIPTION
Will fix https://github.com/sferik/rails_admin/issues/2785. Based on https://github.com/rails/rails/issues/23589#issuecomment-229247727.