### PR TITLE
Fixed datepicker for some locales

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -67,6 +67,8 @@
         break;
         case 'string':
         case 'text':
+        case 'has_many_association':
+        case 'has_one_association':
         case 'belongs_to_association':
           control = '<select class="switch-additionnal-fieldsets input-sm form-control" value="' + field_operator + '" name="' + operator_name + '">' +
             '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +

--- a/app/views/rails_admin/main/_delete_notice.html.haml
+++ b/app/views/rails_admin/main/_delete_notice.html.haml
@@ -9,6 +9,7 @@
     = wording
   %ul
     - @abstract_model.each_associated_children(object) do |association, children|
+      - next if @auditing_adapter && @auditing_adapter.respond_to?(:is_auditing_association) && @auditing_adapter.is_auditing_association(association.association)
       - humanized_association = @abstract_model.model.human_attribute_name association.name
       - limit = children.count > 12 ? 10 : children.count
       - children.first(limit).each do |child|

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -30,6 +30,7 @@ module RailsAdmin
       end
 
       class AuditingAdapter
+
         COLUMN_MAPPING = {
           table: :item_type,
           username: :whodunnit,
@@ -85,6 +86,10 @@ module RailsAdmin
 
         def listing_for_object(model, object, query, sort, sort_reverse, all, page, per_page = (RailsAdmin::Config.default_items_per_page || 20))
           listing_for_model_or_object(model, object, query, sort, sort_reverse, all, page, per_page)
+        end
+
+        def is_auditing_association(association)
+          association.class_name == @version_class.to_s
         end
 
       protected

--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -56,6 +56,10 @@ module RailsAdmin
           policy(record).try(:attributes_for, action) || {}
         end
 
+        def is_auditing_association(association)
+          false
+        end
+
       private
 
         def policy(record)

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -39,11 +39,11 @@ module RailsAdmin
               english = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
               abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
             when '%B'
-              english = [nil, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][1..-1]
-              month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              english = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"].reverse
+              month_names.reverse.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
             when '%b'
-              english = [nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][1..-1]
-              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              english = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"].reverse
+              abbr_month_names.reverse.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
             when '%p'
               date_string = date_string.gsub(/#{::I18n.t('date.time.am', default: "am")}/, 'am')
               date_string = date_string.gsub(/#{::I18n.t('date.time.pm', default: "pm")}/, 'pm')


### PR DESCRIPTION
I think this is one source of the translation problem for datepicker, which manifest itself by failing to save date attribute to database.

In summary:
Double digit month should be matched first. For example, `11月` should be matched before `1月`. Otherwise a string like 2016年11月1日 would be translated to 2016年1Jan1日 because 1月 is matched first and then there is a remaining `1`.