### PR TITLE
Fix #encoding error by oracle_enhanced

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -72,6 +72,8 @@ module RailsAdmin
           ::ActiveRecord::Base.connection.select_one("SELECT ''::text AS str;").values.first.encoding
         when 'mysql2'
           ::ActiveRecord::Base.connection.instance_variable_get(:@connection).encoding
+        when 'oracle_enhanced'
+          ::ActiveRecord::Base.connection.select_one("SELECT dummy FROM DUAL").values.first.encoding
         else
           ::ActiveRecord::Base.connection.select_one("SELECT '' AS str;").values.first.encoding
         end


### PR DESCRIPTION
An error occurs because Oracle cannot omit `FROM`. 
```rb
$ bin/rails c
Loading development environment (Rails 5.0.0.1)
ruby 2.3.3 [1] pry(main)> ::ActiveRecord::Base.connection.select_one("SELECT '' AS str;").values.first.encoding
   (2.4ms)  SELECT '' AS str;
ActiveRecord::StatementInvalid: OCIError: ORA-00911: invalid character: SELECT '' AS str;
from stmt.c:243:in oci8lib_230.bundle
```

In the case of Oracle, I want to execute the following SQL:
```rb
$ bin/rails c
Loading development environment (Rails 5.0.0.1)
ruby 2.3.3 [1] pry(main)> ::ActiveRecord::Base.connection.select_one("SELECT dummy FROM DUAL").values.first.encoding
   (0.9ms)  SELECT dummy FROM DUAL
=> #<Encoding:UTF-8>
```

ref. https://github.com/rsim/oracle-enhanced