### PR TITLE
Add config option to set locale

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -16,6 +16,7 @@ module RailsAdmin
     before_action :_authenticate!
     before_action :_authorize!
     before_action :_audit!
+    before_action :_set_locale!
 
     helper_method :_current_user, :_get_plugin_name
 
@@ -56,6 +57,10 @@ module RailsAdmin
 
     def _audit!
       instance_eval(&RailsAdmin::Config.audit_with)
+    end
+
+    def _set_locale!
+      I18n.locale = RailsAdmin.config.locale if RailsAdmin.config.locale
     end
 
     def rails_admin_controller?

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -78,6 +78,9 @@ module RailsAdmin
       # yell about fields that are not marked as accessible
       attr_accessor :yell_for_non_accessible_fields
 
+      # set locale for rails_admin
+      attr_accessor :locale
+
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #

--- a/spec/controllers/rails_admin/application_controller_spec.rb
+++ b/spec/controllers/rails_admin/application_controller_spec.rb
@@ -39,4 +39,12 @@ describe RailsAdmin::ApplicationController, type: :controller do
       expect(controller.send(:rails_admin_controller?)).to be true
     end
   end
+
+  describe '#_set_locale!' do
+    it 'works with config' do
+      RailsAdmin.config.locale = :fr
+      controller.send(:_set_locale!)
+      expect(I18n.locale).to eq(:fr)
+    end
+  end
 end


### PR DESCRIPTION
I want to use locale ':ja' but my rails app's default_locale must be ':en'. So I tried to enable to set locale for active_admin by config file.

### Usage

```ruby
# config/initializers/rails_admin.rb
RailsAdmin.config do |config|
  config.locale = :ja # I18n.locale is assigned :ja only scoped for active_admin.
 ~~~
end
```