### PR TITLE
Loosen the dependency version of Kaminari (1.0.0)

### DIFF
--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal", ">= 2.0"
 gem "devise", ">= 3.2"
+gem "kaminari", "~> 0.14"
 gem "rails", "~> 4.0.0"
 gem "sass-rails", "~> 4.0.3"
 gem "test-unit"
@@ -59,7 +60,7 @@ end
 
 group :mongoid do
   gem "mongoid", "~> 4.0"
-  gem "kaminari-mongoid"
+  gem "kaminari-mongoid", "~> 0.1"
   gem "mongoid-paperclip", ">= 0.0.8", :require => "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", :require => "carrierwave/mongoid"
   gem "refile-mongoid", ">= 0.0.1", :platforms => [:ruby_21, :ruby_22, :ruby_23]

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'haml', '~> 4.0'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
-  spec.add_dependency 'kaminari', '~> 0.14'
+  spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'
   spec.add_dependency 'nested_form', '~> 0.3'
   spec.add_dependency 'rack-pjax', '>= 0.7'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']


### PR DESCRIPTION
Kaminari v1.0.0 is released.

- https://rubygems.org/gems/kaminari/versions/1.0.0
- https://github.com/kaminari/kaminari/blob/master/CHANGELOG.md#100

It seems no problem at my environment. (Ruby 2.3.3, Rails 5.0.0.1)
