### PR TITLE
Update README install directions to use 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This problem was reported by SourceClear, Inc.
 
 ## Installation
 
-1. On your gemfile: `gem 'rails_admin', '~> 1.0'`
+1. On your gemfile: `gem 'rails_admin', '~> 1.1.1'`
 2. Run `bundle install`
 3. Run `rails g rails_admin:install`
 4. Provide a namespace for the routes when asked


### PR DESCRIPTION
### Problem

At the top of the README, `rails_admin` [encourages using `1.1.1`](https://github.com/sferik/rails_admin#action-required-security-issue), however `'~> 1.0'` is shown in the [installation](https://github.com/sferik/rails_admin#installation) instructions, leading to some confusion.

### Solution

Update the README to show the latest version.