### PR TITLE
Handle datetime after switching locales properly

### DIFF
--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -9,7 +9,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           def parser
-            @parser ||= RailsAdmin::Support::Datetime.new(strftime_format)
+            RailsAdmin::Support::Datetime.new(strftime_format)
           end
 
           def parse_value(value)

--- a/spec/rails_admin/config/fields/types/datetime_spec.rb
+++ b/spec/rails_admin/config/fields/types/datetime_spec.rb
@@ -87,5 +87,19 @@ describe RailsAdmin::Config::Fields::Types::Datetime do
       @object.datetime_field = field.parse_input(datetime_field: 'Sat, 01 Sep 2012 12:00:00 +0200')
       expect(@object.datetime_field).to eq(Time.zone.parse('2012-09-01 12:00:00 +02:00'))
     end
+
+    it 'changes formats when the locale changes' do
+      french_format = "%A %d %B %Y %H:%M"
+      allow(I18n).to receive(:t).with(:long, scope: [:time, :formats], raise: true).and_return(french_format)
+      @object = FactoryGirl.create(:field_test)
+      @object.datetime_field = field.parse_input(datetime_field: @time.strftime(french_format))
+      expect(@object.datetime_field.strftime(french_format)).to eq(@time.strftime(french_format))
+
+      american_format = "%B %d, %Y %H:%M"
+      allow(I18n).to receive(:t).with(:long, scope: [:time, :formats], raise: true).and_return(american_format)
+      @object = FactoryGirl.create(:field_test)
+      @object.datetime_field = field.parse_input(datetime_field: @time.strftime(american_format))
+      expect(@object.datetime_field.strftime(american_format)).to eq(@time.strftime(american_format))
+    end
   end
 end


### PR DESCRIPTION
When switching locales, our datetime fields were not displaying in the proper format. Removing the memo-ization of @parser in the Datetime field type fixes the problem.

Would be happy to pair with a maintainer or contributor who knows the codebase and project spec style better.