### PR TITLE
Add ability to show papertrail models

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -203,7 +203,7 @@ module RailsAdmin
 
       # pool of all found model names from the whole application
       def models_pool
-        excluded = (excluded_models.collect(&:to_s) + %w(RailsAdmin::History PaperTrail::Version PaperTrail::VersionAssociation))
+        excluded = (excluded_models.collect(&:to_s) + ['RailsAdmin::History']
 
         (viable_models - excluded).uniq.sort
       end


### PR DESCRIPTION
Users are can't show paper_trail models in UI with default names, because they were added in excluded models.