### PR TITLE
Fix params key for namespaced models in new action

### DIFF
--- a/lib/rails_admin/config/actions/new.rb
+++ b/lib/rails_admin/config/actions/new.rb
@@ -20,7 +20,7 @@ module RailsAdmin
               @authorization_adapter && @authorization_adapter.attributes_for(:new, @abstract_model).each do |name, value|
                 @object.send("#{name}=", value)
               end
-              if object_params = params[@abstract_model.to_param]
+              if object_params = params[@abstract_model.param_key]
                 sanitize_params_for!(request.xhr? ? :modal : :create)
                 @object.set_attributes(@object.attributes.merge(object_params.to_h))
               end

--- a/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
+++ b/spec/integration/basic/new/rails_admin_namespaced_model_new_spec.rb
@@ -16,15 +16,23 @@ describe 'RailsAdmin Namespaced Model New', type: :request do
   end
 
   describe 'GET /admin/cms_basic_page/new' do
-    before do
-      visit new_path(model_name: 'cms~basic_page')
-    end
-
     it 'has correct input field names' do
+      visit new_path(model_name: 'cms~basic_page')
+
       is_expected.to have_selector('label[for=cms_basic_page_title]')
       is_expected.to have_selector("input#cms_basic_page_title[name='cms_basic_page[title]']")
       is_expected.to have_selector('label[for=cms_basic_page_content]')
       is_expected.to have_selector("textarea#cms_basic_page_content[name='cms_basic_page[content]']")
+    end
+
+    it 'has default values' do
+      content = '4123lkj1sdlfjasdfjsdkfjsdfk'
+
+      visit new_path(model_name: 'cms~basic_page', cms_basic_page: {content: content})
+
+      within('#cms_basic_page_content_field') do
+        is_expected.to have_content(content)
+      end
     end
   end
 end


### PR DESCRIPTION
### Overview ###
Fixed using namespaced model default params in new action.

Previous implementation: `new?namespace~model[value]=123`.
Current implementation: `new?namespace_model[value]=123`.

Please look at test which describe the issue.