### PR TITLE
Use jQuery2 

### DIFF
--- a/app/assets/javascripts/rails_admin/rails_admin.js
+++ b/app/assets/javascripts/rails_admin/rails_admin.js
@@ -1,4 +1,4 @@
-//=  require 'jquery'
+//=  require 'jquery2'
 //=  require 'jquery_ujs'
 //=  require 'jquery.remotipart'
 //=  require 'jquery-ui/effect'


### PR DESCRIPTION
As I said in this [issue](https://github.com/sferik/rails_admin/issues/2838), jQuery 3 is causing the gem to break.

I ran the tests and it seems like reverting to jQuery2 does not break anything. 