### PR TITLE
Loosen the dependency version of Haml

### DIFF
--- a/config/initializers/haml.rb
+++ b/config/initializers/haml.rb
@@ -1,2 +1,5 @@
 require 'haml'
-Haml::Template.options[:ugly] = true
+
+if Gem::Version.create(Haml::VERSION) < Gem::Version.create('5.0.0.beta.2')
+  Haml::Template.options[:ugly] = true
+end

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'builder', '~> 3.1'
   spec.add_dependency 'coffee-rails', '~> 4.0'
   spec.add_dependency 'font-awesome-rails', ['>= 3.0', '< 5']
-  spec.add_dependency 'haml', '~> 4.0'
+  spec.add_dependency 'haml', '>= 4.0', '< 6'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'


### PR DESCRIPTION
Haml 5.0.0.beta.2 is out.

[This version will bring 3x rendering speed-up.](https://twitter.com/a_matsuda/status/835819589090988032)

And, this PR suppress the following warning associated with upgrading.

```
Haml::TempleEngine: Option :ugly is invalid
```

Refer: https://github.com/haml/haml/pull/894

I'd like to use it as soon as possible.

Thanks.