### PR TITLE
changes size() to length since it is missing in jquery 3.0

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-select.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-select.js
@@ -40,7 +40,7 @@
       // When using the browser back and forward buttons, it is possible that
       // the autocomplete field will be cached which causes duplicate fields
       // to be generated.
-      if (filtering_select.size() > 0) {
+      if (filtering_select.length > 0) {
         this.input = filtering_select.children('input');
         this.button = filtering_select.children('.input-group-btn');
       } else {


### PR DESCRIPTION
this piece of code cause my rails_Admin backend to basically stop working since jquery 3 removed the size() function. Using .length fixes the issue for me