### PR TITLE
customizable menu

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -85,9 +85,7 @@ module RailsAdmin
     end
 
     def root_navigation
-
       actions(:root).select(&:show_in_sidebar).group_by(&:sidebar_label).collect do |label, nodes|
-
         li_stack = nodes.map do |node|
           url = rails_admin.url_for(action: node.action_name, controller: "rails_admin/main")
           nav_icon = node.link_icon ? %(<i class="#{node.link_icon}"></i>).html_safe : ''
@@ -95,7 +93,7 @@ module RailsAdmin
             link_to nav_icon + " " + wording_for(:menu, node), url, class: "pjax"
           end
         end.join.html_safe
-        label = label || t('admin.misc.root_navigation')
+        label ||= t('admin.misc.root_navigation')
 
         %(<li class='dropdown-header'>#{capitalize_first_letter label}</li>#{li_stack}) if li_stack.present?
       end.join.html_safe

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -1,5 +1,5 @@
 %ul.nav.navbar-nav.navbar-right.root_links
-  - actions(:root).each do |action|
+  - actions(:root).select(&:show_in_navigation).each do |action|
     %li{class: "#{action.action_name}_root_link"}= link_to wording_for(:menu, action), { action: action.action_name, controller: 'rails_admin/main' }, class: action.pjax? ? "pjax" : ""
   - if main_app_root_path = (main_app.root_path rescue false)
     %li= link_to t('admin.home.name'), main_app_root_path

--- a/app/views/layouts/rails_admin/_sidebar_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_sidebar_navigation.html.haml
@@ -1,2 +1,3 @@
 %ul.nav.nav-pills.nav-stacked= main_navigation
+%ul.nav.nav-pills.nav-stacked= root_navigation
 %ul.nav.nav-pills.nav-stacked= static_navigation

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -41,6 +41,7 @@ en:
       up: "Up"
       down: "Down"
       navigation: "Navigation"
+      root_navigation: "Actions"
       navigation_static_label: "Links"
       log_out: "Log out"
       ago: "ago"

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -18,6 +18,22 @@ module RailsAdmin
           []
         end
 
+        register_instance_option :show_in_navigation do
+          root?
+        end
+
+        register_instance_option :show_in_sidebar do
+          !show_in_navigation
+        end
+
+        register_instance_option :show_in_menu do
+          !show_in_sidebar
+        end
+
+        register_instance_option :sidebar_label do
+          nil
+        end
+
         # http://getbootstrap.com/2.3.2/base-css.html#icons
         register_instance_option :link_icon do
           'icon-question-sign'

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -27,7 +27,7 @@ module RailsAdmin
         end
 
         register_instance_option :show_in_menu do
-          !show_in_sidebar
+          true
         end
 
         register_instance_option :sidebar_label do


### PR DESCRIPTION
Gives custom actions the ability not to show up in the topnavigation, but below custom labels in the sidenavigation.
This way the navigation is more intuitive, if you're using custom actions excessively.

solves #2773 
extends #2345 