### PR TITLE
Find the last created record by `created_at` field, not primary key

### DIFF
--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -27,7 +27,7 @@ module RailsAdmin
                 @max = current_count > @max ? current_count : @max
                 @count[t.model.name] = current_count
                 next unless t.properties.detect { |c| c.name == :created_at }
-                @most_recent_created[t.model.name] = t.model.last.try(:created_at)
+                @most_recent_created[t.model.name] = t.model.order(created_at: :desc).limit(1).pluck(:created_at).first
               end
             end
             render @action.template_name, status: @status_code || :ok

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -57,6 +57,16 @@ describe RailsAdmin::MainController, type: :controller do
       expect(controller.instance_variable_get('@most_recent_created')['User::Confirmed']).to eq user_create
       expect(controller.instance_variable_get('@most_recent_created')['Comment::Confirmed']).to eq comment_create
     end
+
+    it 'finds last created record by created_at field, not primary key' do
+      first_comment_create = 20.days.ago.to_date
+      last_comment_create = 10.days.ago.to_date
+      FactoryGirl.create(:comment_confirmed, created_at: last_comment_create)
+      FactoryGirl.create(:comment_confirmed, created_at: first_comment_create)
+
+      controller.dashboard
+      expect(controller.instance_variable_get('@most_recent_created')['Comment::Confirmed']).to eq last_comment_create
+    end
   end
 
   describe '#check_for_cancel' do


### PR DESCRIPTION
The `.last` method by default finds the last record ordered by primary key.
The `created_at` column and a primary key column don't always come in the same order.
So, in order to find the last created record we should order explicitly by `created_at` column.

Since we only need to get the `created_at` value, there is no need to load and instantiate the whole record.
We can fetch just `created at` value using `.pluck` method.