### PR TITLE
Use phantomjs2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
-dist: trusty
-
 language: ruby
 
 before_install: gem install bundler
 
 before_script:
-  - phantomjs --version
   - cd spec/dummy_app
   - bundle exec rake rails_admin:prepare_ci_env db:create db:migrate
   - cd ../../
@@ -33,6 +30,7 @@ gemfile:
 services:
   - mongodb
   - mysql
+  - postgresql
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ gemfile:
 
 services:
   - mongodb
+  - mysql
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+dist: trusty
+
 language: ruby
 
 before_install: gem install bundler
 
 before_script:
+  - phantomjs --version
   - cd spec/dummy_app
   - bundle exec rake rails_admin:prepare_ci_env db:create db:migrate
   - cd ../../


### PR DESCRIPTION
`Trusty` environment on `travis` has **phantomjs** `2.0.0` instead of `1.9.3` in `precise`

@see https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-151367517