### PR TITLE
show warning if field has 'dependent: :destroy' option

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -51,6 +51,10 @@
       this.filter = $('<input type="search" placeholder="' + this.options.regional.search + '" class="form-control ra-multiselect-search"/>');
 
       this.header.append(this.filter);
+      if (this.options.dependent_destroy && this.options.removable) {
+        this.dependent_destroy_warning = $('<label class="extra-label">' + this.options.regional.dependent_destroy_warning + '</label>');
+        this.header.append(this.dependent_destroy_warning);
+      }
 
       this.wrapper.append(this.header);
 

--- a/app/assets/stylesheets/rails_admin/bootstrap/_labels.scss
+++ b/app/assets/stylesheets/rails_admin/bootstrap/_labels.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.extra-label{
+  margin-top: 0.5rem;
+}
+
 // Add hover effects, but only for links
 a.label {
   &:hover,

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -28,13 +28,15 @@
     sortable: !!field.orderable,
     removable: !!field.removable,
     cacheAll: !!field.associated_collection_cache_all,
+    dependent_destroy: field.properties.options[:dependent]==:destroy,
     regional: {
       chooseAll: t("admin.misc.chose_all"),
       chosen: t("admin.misc.chosen", name: config.label_plural),
       clearAll: t("admin.misc.clear_all"),
       search: t("admin.misc.search"),
       up: t("admin.misc.up"),
-      down: t("admin.misc.down")
+      down: t("admin.misc.down"),
+      dependent_destroy_warning: (t("admin.misc.dependent_destroy") if field.properties.options[:dependent]==:destroy)
     }
   }
 

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -45,6 +45,7 @@ en:
       log_out: "Log out"
       ago: "ago"
       more: "Plus %{count} more %{models_name}"
+      dependent_destroy: "Orphan records will be deleted due to 'dependent: :destroy' option!"
     flash:
       successful: "%{name} successfully %{action}"
       error: "%{name} failed to be %{action}"


### PR DESCRIPTION
When `dependent: :destroy` option is set, we show two windows with multiselect, but it's not obvious that orphan records might be deleted(when admin detach records from parent with _ra-multiselect-item-remove_). I've added warning for this case 
https://github.com/sferik/rails_admin/issues/2762 

P.S. Sorry for creating PR without tests: I haven't managed to run them locally because of 'Please set up Papertrail's version model explicitly. ' error, so I've created PR to run tests on CI first