### PR TITLE
Use data attribute to fetch admin.js options

### DIFF
--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -8,10 +8,11 @@
     = csrf_meta_tag
     = stylesheet_link_tag "rails_admin/rails_admin.css", media: :all
     = javascript_include_tag "rails_admin/rails_admin.js"
+  %body.rails_admin
+    #admin-js{:'data-i18n-options' => I18n.t("admin.js").to_json}
     -# Initialize JS simple i18n
     :javascript
-      RailsAdmin.I18n.init('#{I18n.locale}', JSON.parse("#{j I18n.t("admin.js").to_json}"))
-  %body.rails_admin
+      RailsAdmin.I18n.init('#{I18n.locale}', document.getElementById("admin-js").dataset.i18nOptions);
     #loading.label.label-warning{style: 'display:none; position:fixed; right:20px; bottom:20px; z-index:100000'}= t('admin.loading')
     %nav.navbar.navbar-default.navbar-fixed-top
       = render "layouts/rails_admin/navigation"


### PR DESCRIPTION
## Background
Since Haml 4 doesn't escape interpolated Ruby script, the result of `j I18n.t("admin.js").to_json` is not HTML-escaped and it's working.

## Problem
But in Haml 5, such interpolated script is HTML-escaped by default https://github.com/haml/haml/pull/770. 
Thus, with Haml 5.0.0.beta.2, it's broken like:

```
Uncaught SyntaxError: Unexpected token & in JSON at position 1
    at JSON.parse (<anonymous>)
    at admin:53
```

## Changes
For security, it'd be good to have it in HTML-escaped form. So, I changed the template to fetch it from data attribute. Using data attribute, we can store JSON object in HTML-escaped form and fetch it safely.