### PR TITLE
Haml upgrade (removes Erubis deprecation warning)

### DIFF
--- a/config/initializers/haml.rb
+++ b/config/initializers/haml.rb
@@ -1,2 +1,5 @@
 require 'haml'
-Haml::Template.options[:ugly] = true
+require 'haml/template'
+if Haml::Options.buffer_option_keys.include?(:ugly)
+  Haml::Template.options[:ugly] = true
+end

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'builder', '~> 3.1'
   spec.add_dependency 'coffee-rails', '~> 4.0'
   spec.add_dependency 'font-awesome-rails', ['>= 3.0', '< 5']
-  spec.add_dependency 'haml', '~> 4.0'
+  spec.add_dependency 'haml', ['> 4.0', '< 6']
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'jquery-ui-rails', '~> 5.0'
   spec.add_dependency 'kaminari', '~> 0.14'


### PR DESCRIPTION
The haml gem has been updated to version 5, but rails_admin requires ~4. I originally came across this to get rid of the deprecation warnings: `DEPRECATION WARNING: ActionView::Template::Handlers::Erubis is deprecated and will be removed from Rails 5.2. Switch to ActionView::Template::Handlers::ERB::Erubi instead.`.

This seems to do the trick. However, I could use some help getting across the finish line.

- There are a few failing tests ([gist](https://gist.github.com/ordinaryzelig/e21e7470c184e90ca1d80d4aa1930f90#file-rails_admin_rspec_failures)) that appear to be JS related.
- I was unable to get the tests to work on ruby 2.4.0 ([rspec log](https://gist.github.com/ordinaryzelig/e21e7470c184e90ca1d80d4aa1930f90#file-ruby-2-4-0-errors)). Although, the updated gem works on a ruby-2.4.0 project that uses a local version of the modified code.