### PR TITLE
IrreversibleOrderError patch

### DIFF
--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -27,7 +27,11 @@ module RailsAdmin
                 @max = current_count > @max ? current_count : @max
                 @count[t.model.name] = current_count
                 next unless t.properties.detect { |c| c.name == :created_at }
-                @most_recent_created[t.model.name] = t.model.last.try(:created_at)
+                begin
+                  @most_recent_created[t.model.name] = t.model.last.try(:created_at)
+                rescue ::ActiveRecord::IrreversibleOrderError => e
+                  @most_recent_created[t.model.name] = nil
+                end
               end
             end
             render @action.template_name, status: @status_code || :ok


### PR DESCRIPTION
I had an issue where one of my models was using a default sort scope with NULLS LAST

Since upgrading to Rails 5.1.1 I got IrreversibleOrderError raised on loading rails_admin - by loading I mean visiting the /admin route.

Not sure of any other side effects from this but for me at least it means rails admin no longer just falls over with a 500 - and if this doesn't get merged it can at least serve as a heads up

Thanks

Kev