### PR TITLE
fix Consider running tests without papertrail

### DIFF
--- a/spec/integration/history/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/history/rails_admin_paper_trail_spec.rb
@@ -126,4 +126,4 @@ describe 'RailsAdmin PaperTrail history', active_record: true do
       end
     end
   end
-end
+end if defined?(PaperTrail)


### PR DESCRIPTION
## Overview

If you test as it is, paper_trail will not be in ./Gemfile and the test will fail

## My Environments

- OSX 10.12.4
- postgresql 9.6.3
- node v6.9.5
- phantomjs 2.1.1

## Step to reproduce

```bash
$ bundle exec rake spec

# ...

Failures:

  1) RailsAdmin PaperTrail history model history fetch creates versions
     Failure/Error: PaperTrail::Version.delete_all

     NameError:
       uninitialized constant PaperTrail::Version
     # ./spec/integration/history/rails_admin_paper_trail_spec.rb:41:in `block (3 levels) in <top (required)>'
```

## Solution

Implemented not to run test because there is no paper_trail gem in ./Gemfile

## Otherwise

Even if paper_trail is added to ./Gemfile

```diff
diff --git a/Gemfile b/Gemfile
index 01a57121..821b30e5 100644
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'haml'
 gem 'devise'

 group :active_record do
+
+  gem "paper_trail", "~> 5.0"
+
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '~> 0.3.14'
     gem 'pg', '>= 0.14'
```