### PR TITLE
version bump

### DIFF
--- a/lib/rails_admin/version.rb
+++ b/lib/rails_admin/version.rb
@@ -2,7 +2,7 @@ module RailsAdmin
   class Version
     MAJOR = 1
     MINOR = 1
-    PATCH = 1
+    PATCH = 2
     PRE = nil
 
     class << self


### PR DESCRIPTION
There are some changes made, mainly the removal of `alias_chain_method` that throw some deprecation warnings in Rails 5, that are not being applied due to the lack of a version bump.