### PR TITLE
fix HTML of filter refresh on history page

### DIFF
--- a/app/views/rails_admin/main/history.html.haml
+++ b/app/views/rails_admin/main/history.html.haml
@@ -10,7 +10,7 @@
     .input-group
       %input.form-control.input-small{name: "query", type: "search", value: query, placeholder: "#{t("admin.misc.filter")}", class: 'input-small'}
       %span.input-group-btn
-        %button.btn.btn-primary{type: "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("admin.misc.refresh")}
+        %button.btn.btn-primary{type: 'submit', :'data-disable-with' => '<i class="icon-white icon-refresh"></i> '.html_safe + t('admin.misc.refresh')}
           %i.icon-white.icon-refresh
           = t("admin.misc.refresh")
 %table#history.table.table-striped.table-condensed


### PR DESCRIPTION
Provides a fix for https://github.com/sferik/rails_admin/issues/2889 so that the filter button looks correct again. Same approach as https://github.com/sferik/rails_admin/pull/2706

![image](https://cloud.githubusercontent.com/assets/1628558/26753922/a00b3968-4868-11e7-8156-d451a323ee2f.png)
