### PR TITLE
Escape quotes in field values to prevent XSS attacks.

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -21,6 +21,10 @@
         field_value = field_value.replace('"', '&quot;');
       }
 
+      if (typeof(field_operator) === "string") {
+        field_operator = field_operator.replace('"', '&quot;');
+      }
+
       switch(field_type) {
         case 'boolean':
           var control = '<select class="input-sm form-control" name="' + value_name + '">' +

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -17,6 +17,10 @@
       var control = null;
       var additional_control = null;
 
+      if (typeof(field_value) === "string") {
+        field_value = field_value.replace('"', '&quot;');
+      }
+
       switch(field_type) {
         case 'boolean':
           var control = '<select class="input-sm form-control" name="' + value_name + '">' +


### PR DESCRIPTION
Prior to this commit, one could inject a script tag into the filter box field value by passing the following string as a filter value: ' "><script>...</script>' which would then execute the contents of the script element. This fixes the issue by replacing double quotes (") with &quot;.