### PR TITLE
fix: save_and_edit should authorize the current object

### DIFF
--- a/app/views/rails_admin/main/_submit_buttons.html.haml
+++ b/app/views/rails_admin/main/_submit_buttons.html.haml
@@ -8,7 +8,7 @@
       - if authorized? :new, @abstract_model
         %button.btn.btn-info{type: "submit", name: "_add_another", :'data-disable-with' => t("admin.form.save_and_add_another")}
           = t("admin.form.save_and_add_another")
-      - if authorized? :edit, @abstract_model
+      - if authorized? :edit, @abstract_model, @object
         %button.btn.btn-info{type: "submit", name: "_add_edit", :'data-disable-with' => t("admin.form.save_and_edit")}
           = t("admin.form.save_and_edit")
       %button.btn.btn-default{type: "submit", name: "_continue", :'data-disable-with' => t("admin.form.cancel"), :formnovalidate => true}


### PR DESCRIPTION
was authorizing the class. 

Not sure why I'm the first person to see this. Looks old I found this https://github.com/sferik/rails_admin/commit/4ec9719920fb23019ce65b417ff5c4463a9b5e3f#commitcomment-22816721

I was kind of surprised my `edit?` policy (using Pundit) was called twice.  The first time it was authorizing the instance and the second the class.  It might be better to pass in a local to the partial since whether or not we can edit has already been determined

