### PR TITLE
Fix for translation filters

### DIFF
--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -12,7 +12,7 @@
     #admin-js{:'data-i18n-options' => I18n.t("admin.js").to_json}
     -# Initialize JS simple i18n
     :javascript
-      RailsAdmin.I18n.init('#{I18n.locale}', document.getElementById("admin-js").dataset.i18nOptions);
+      RailsAdmin.I18n.init('#{I18n.locale}', JSON.parse(document.getElementById("admin-js").dataset.i18nOptions));
     #loading.label.label-warning{style: 'display:none; position:fixed; right:20px; bottom:20px; z-index:100000'}= t('admin.loading')
     %nav.navbar.navbar-default.navbar-fixed-top
       = render "layouts/rails_admin/navigation"


### PR DESCRIPTION
The JSON of JS translations was passed as text, so the translation was never found.
The solution was to add parse to the text to convert it to JSON.