### PR TITLE
Toggle checkboxes

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -18,7 +18,8 @@
   other_right = sets[params[:set].to_i + 1].present?
 
 - content_for :contextual_tabs do
-  = bulk_menu
+  - if checkboxes
+    = bulk_menu
   - if filterable_fields.present?
     %li.dropdown{style: 'float:right'}
       %a.dropdown-toggle{href: '#', :'data-toggle' => "dropdown"}

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -10,6 +10,7 @@
   export_action = nil unless export_action && authorized?(export_action.authorization_key, @abstract_model)
   description = RailsAdmin.config(@abstract_model.model_name).description
   properties = @model_config.list.with(controller: self.controller, view: self, object: @abstract_model.model.new).visible_fields
+  checkboxes = @model_config.list.checkboxes?
   # columns paginate
   sets = get_column_sets(properties)
   properties = sets[params[:set].to_i] || []
@@ -75,8 +76,9 @@
     %table.table.table-condensed.table-striped
       %thead
         %tr
-          %th.shrink
-            %input.toggle{type: "checkbox"}
+          - if checkboxes
+            %th.shrink
+              %input.toggle{type: "checkbox"}
           - if other_left
             %th.other.left.shrink= "..."
           - properties.each do |property|
@@ -91,8 +93,8 @@
       %tbody
         - @objects.each do |object|
           %tr{class: "#{@abstract_model.param_key}_row #{@model_config.list.with(object: object).row_css_class}"}
-            %td
-              = check_box_tag "bulk_ids[]", object.id, false
+            - if checkboxes
+              %td= check_box_tag "bulk_ids[]", object.id, false
             - if @other_left_link ||= other_left && index_path(params.except('set').merge(params[:set].to_i != 1 ? {set: (params[:set].to_i - 1)} : {}))
               %td.other.left= link_to "...", @other_left_link, class: 'pjax'
             - properties.map{ |property| property.bind(:object, object) }.each do |property|

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -5,6 +5,10 @@ module RailsAdmin
     module Sections
       # Configuration of the list view
       class List < RailsAdmin::Config::Sections::Base
+        register_instance_option :checkboxes? do
+          true
+        end
+
         register_instance_option :filters do
           []
         end

--- a/spec/integration/config/list/rails_admin_config_list_spec.rb
+++ b/spec/integration/config/list/rails_admin_config_list_spec.rb
@@ -434,4 +434,40 @@ describe 'RailsAdmin Config DSL List Section', type: :request do
       is_expected.not_to have_link('embed 1')
     end
   end
+
+  describe 'checkboxes?' do
+    describe 'default is enabled' do
+      before do
+        RailsAdmin.config FieldTest do
+          list
+        end
+      end
+
+      it 'displays checkboxes on index' do
+        @records = FactoryGirl.create_list :field_test, 3
+
+        visit index_path(model_name: 'field_test')
+        checkboxes = all(:xpath, './/form[@id="bulk_form"]//input[@type="checkbox"]')
+        expect(checkboxes.length).to be > 0
+      end
+    end
+
+    describe 'false' do
+      before do
+        RailsAdmin.config FieldTest do
+          list do
+            checkboxes false
+          end
+        end
+      end
+
+      it 'does not display any checkboxes on index' do
+        @records = FactoryGirl.create_list :field_test, 3
+
+        visit index_path(model_name: 'field_test')
+        checkboxes = all(:xpath, './/form[@id="bulk_form"]//input[@type="checkbox"]')
+        expect(checkboxes.length).to eq 0
+      end
+    end
+  end
 end

--- a/spec/integration/config/list/rails_admin_config_list_spec.rb
+++ b/spec/integration/config/list/rails_admin_config_list_spec.rb
@@ -449,6 +449,8 @@ describe 'RailsAdmin Config DSL List Section', type: :request do
         visit index_path(model_name: 'field_test')
         checkboxes = all(:xpath, './/form[@id="bulk_form"]//input[@type="checkbox"]')
         expect(checkboxes.length).to be > 0
+
+        expect(page).to have_content('Selected items')
       end
     end
 
@@ -467,6 +469,8 @@ describe 'RailsAdmin Config DSL List Section', type: :request do
         visit index_path(model_name: 'field_test')
         checkboxes = all(:xpath, './/form[@id="bulk_form"]//input[@type="checkbox"]')
         expect(checkboxes.length).to eq 0
+
+        expect(page).not_to have_content('Selected items')
       end
     end
   end


### PR DESCRIPTION
This adds the ability to toggle the checkboxes on the list section. The bulk menu is also disabled whenever the checkboxes instance variable is set to false on the list section. 

The reason for this feature is to remove some of the clutter on the list page if no bulk actions are being used. Some of our clients have said it's distracting without bulk actions being available. 

All tests are passing on CentOS 7 with Ruby 2.3.3. Code coverage has increased. 