### PR TITLE
Fix JS translations not be object but string

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.i18n.coffee
+++ b/app/assets/javascripts/rails_admin/ra.i18n.coffee
@@ -2,6 +2,8 @@
 @RailsAdmin.I18n = class Locale
   @init: (@locale, @translations)->
     moment.locale(@locale)
+    if typeof(@translations) == "string"
+      @translations = JSON.parse(@translations)
 
   @t:(key) ->
     humanize = key.charAt(0).toUpperCase() + key.replace(/_/g, " ").slice(1)


### PR DESCRIPTION
I want to use I18n locale setting but yaml file didn't work.
Because `translations` value become string.

So fix to become `translations` hash.