### PR TITLE
Wrap json field in pre block

### DIFF
--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -10,7 +10,9 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(:jsonb, self)
 
           register_instance_option :formatted_value do
-            value.present? ? JSON.pretty_generate(value) : nil
+            if value.present?
+              bindings[:view].content_tag(:pre) { JSON.pretty_generate(value) }.html_safe
+            end
           end
 
           def parse_value(value)


### PR DESCRIPTION
Resolves issue with json formatting in view https://github.com/sferik/rails_admin/issues/2872.

Rails Admin json api works correctly with this addition and returns plain json. 