### PR TITLE
Fix Fields::Types::Time timezone issue

### DIFF
--- a/lib/rails_admin/config/fields/types/time.rb
+++ b/lib/rails_admin/config/fields/types/time.rb
@@ -11,7 +11,7 @@ module RailsAdmin
             parent_value = super(value)
             return unless parent_value
             value_with_tz = parent_value.in_time_zone
-            ::DateTime.parse(value_with_tz.strftime('%Y-%m-%d %H:%M:%S'))
+            ::DateTime.parse(value_with_tz.strftime('%Y-%m-%d %H:%M:%S %Z'))
           end
 
           register_instance_option :strftime_format do


### PR DESCRIPTION
When Field::Time parses input, it converts the Time to current timezone,
but then throws away the zone info when converting the Time to string
via strftime, so the created DateTime is parsed without the zone
information, thus offsetting the input value to the zone offset hours.