### PR TITLE
Add big table limited pagination

### DIFF
--- a/app/views/kaminari/ra-twitter-bootstrap/without_count/_next_page.html.haml
+++ b/app/views/kaminari/ra-twitter-bootstrap/without_count/_next_page.html.haml
@@ -1,0 +1,4 @@
+- if current_page.last?
+  %li.next.disabled= link_to raw(t 'admin.pagination.next'), '#'
+- else
+  %li.next= link_to raw(t 'admin.pagination.next'), url, class: (remote ? 'pjax' : '')

--- a/app/views/kaminari/ra-twitter-bootstrap/without_count/_paginator.html.haml
+++ b/app/views/kaminari/ra-twitter-bootstrap/without_count/_paginator.html.haml
@@ -1,0 +1,4 @@
+= paginator.render do
+  %ul.pagination
+    = prev_page_tag if !current_page.first?
+    = next_page_tag

--- a/app/views/kaminari/ra-twitter-bootstrap/without_count/_prev_page.html.haml
+++ b/app/views/kaminari/ra-twitter-bootstrap/without_count/_prev_page.html.haml
@@ -1,0 +1,4 @@
+- if current_page.first?
+  %li.prev.disabled= link_to raw(t 'admin.pagination.previous'), '#'
+- else
+  %li.prev= link_to raw(t 'admin.pagination.previous'), url, class: (remote ? 'pjax' : '')

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -106,7 +106,11 @@
             %td.last.links
               %ul.inline.list-inline= menu_for :member, @abstract_model, object, true
 
-    - if @objects.respond_to?(:total_count)
+    - if @model_config.list.limited_pagination
+      .row
+        .col-md-6= paginate(@objects, theme: 'ra-twitter-bootstrap/without_count', total_pages: Float::INFINITY, remote: true)
+
+    - elsif @objects.respond_to?(:total_count)
       - total_count = @objects.total_count.to_i
       .row
         .col-md-6= paginate(@objects, theme: 'ra-twitter-bootstrap', remote: true)

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -18,6 +18,12 @@ module RailsAdmin
           RailsAdmin::Config.default_items_per_page
         end
 
+        # Positive value shows only prev, next links in pagination.
+        # This is for avoiding count(*) query.
+        register_instance_option :limited_pagination do
+          false
+        end
+
         register_instance_option :sort_by do
           parent.abstract_model.primary_key
         end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -338,32 +338,81 @@ describe 'RailsAdmin Basic List', type: :request do
     end
   end
 
-  describe 'GET /admin/player with 3 pages, page 2' do
+  context 'List with 3 pages' do
+    def visit_page(page)
+      visit index_path(model_name: 'player', page: page)
+    end
+
     before do
       RailsAdmin.config.default_items_per_page = 1
-      items_per_page = RailsAdmin.config.default_items_per_page
-      (items_per_page * 3).times { FactoryGirl.create(:player) }
-      visit index_path(model_name: 'player', page: 2)
+      (RailsAdmin.config.default_items_per_page * 3).times { FactoryGirl.create(:player) }
     end
 
-    it 'paginates correctly' do
-      expect(find('ul.pagination li:first')).to have_content('« Prev')
-      expect(find('ul.pagination li:last')).to have_content('Next »')
-      expect(find('ul.pagination li.active')).to have_content('2')
-    end
-  end
+    describe 'with limited_pagination=false' do
+      it 'page 1' do
+        visit_page(1)
 
-  describe 'list with 3 pages, page 3' do
-    before do
-      items_per_page = RailsAdmin.config.default_items_per_page
-      @players = Array.new((items_per_page * 3)) { FactoryGirl.create(:player) }
-      visit index_path(model_name: 'player', page: 3)
+        within('ul.pagination') do
+          expect(find('li:first')).to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+          expect(find('li.active')).to have_content('1')
+        end
+      end
+
+      it 'page 2' do
+        visit_page(2)
+
+        within('ul.pagination') do
+          expect(find('li:first')).to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+          expect(find('li.active')).to have_content('2')
+        end
+      end
+
+      it 'page 3' do
+        visit_page(3)
+
+        within('ul.pagination') do
+          expect(find('li:first')).to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+          expect(find('li.active')).to have_content('3')
+        end
+      end
     end
 
-    it 'paginates correctly and contain the right item' do
-      expect(find('ul.pagination li:first')).to have_content('« Prev')
-      expect(find('ul.pagination li:last')).to have_content('Next »')
-      expect(find('ul.pagination li.active')).to have_content('3')
+    context 'with limited_pagination=true' do
+      before do
+        allow(RailsAdmin::AbstractModel.new(Player).config.list).
+          to receive(:limited_pagination).
+          and_return(true)
+      end
+
+      it 'page 1' do
+        visit_page(1)
+
+        within('ul.pagination') do
+          expect(find('li:first')).not_to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+        end
+      end
+
+      it 'page 2' do
+        visit_page(2)
+
+        within('ul.pagination') do
+          expect(find('li:first')).to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+        end
+      end
+
+      it 'page 3' do
+        visit_page(3)
+
+        within('ul.pagination') do
+          expect(find('li:first')).to have_content('« Prev')
+          expect(find('li:last')).to have_content('Next »')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Overview

Added limited pagination 'prev', 'next' buttons only. It allows not to do `count(*)` which is slowly on big tables.

P.S. If this approach is ok we can reuse it in  https://github.com/sferik/rails_admin/issues/2808