### PR TITLE
Fixed filter by enum filter when label <> value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'devise'
 group :active_record do
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '~> 0.3.14'
-    gem 'pg', '>= 0.14'
+    gem 'pg', "~> 0.21"
     gem 'sqlite3', '>= 1.3'
   end
 end

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -16,7 +16,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem "mysql2", "~> 0.3.14"
-    gem "pg", ">= 0.14"
+    gem "pg", "~> 0.21"
     gem "sqlite3", ">= 1.3"
   end
 

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -13,7 +13,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem "mysql2", "~> 0.3.14"
-    gem "pg", ">= 0.14"
+    gem "pg", "~> 0.21"
     gem "sqlite3", ">= 1.3"
   end
 

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -14,7 +14,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem "mysql2", "~> 0.3.14"
-    gem "pg", ">= 0.14"
+    gem "pg", "~> 0.21"
     gem "sqlite3", ">= 1.3"
   end
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -13,7 +13,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem "mysql2", "~> 0.3.14"
-    gem "pg", ">= 0.14"
+    gem 'pg', '~> 0.21'
     gem "sqlite3", ">= 1.3"
   end
 

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -13,7 +13,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem "mysql2", "~> 0.3.14"
-    gem "pg", ">= 0.14"
+    gem 'pg', '~> 0.21'
     gem "sqlite3", ">= 1.3"
   end
 end

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -101,12 +101,6 @@ module RailsAdmin
 
         def add(field, value, operator)
           field.searchable_columns.flatten.each do |column_infos|
-            value =
-              if value.is_a?(Array)
-                value.map { |v| field.parse_value(v) }
-              else
-                field.parse_value(value)
-              end
             statement, value1, value2 = StatementBuilder.new(column_infos[:column], column_infos[:type], value, operator).to_statement
             @statements << statement if statement.present?
             @values << value1 unless value1.nil?
@@ -126,7 +120,8 @@ module RailsAdmin
       def query_scope(scope, query, fields = config.list.fields.select(&:queryable?))
         wb = WhereBuilder.new(scope)
         fields.each do |field|
-          wb.add(field, field.parse_value(query), field.search_operator)
+          value = parse_field_value(field, query)
+          wb.add(field, value, field.search_operator)
         end
         # OR all query statements
         wb.build

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -15,7 +15,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '~> 0.3.14'
-    gem 'pg', '>= 0.14'
+    gem 'pg', '~> 0.21'
     gem 'sqlite3', '>= 1.3'
   end
 

--- a/spec/dummy_app/app/active_record/field_test.rb
+++ b/spec/dummy_app/app/active_record/field_test.rb
@@ -13,4 +13,7 @@ class FieldTest < ActiveRecord::Base
   mount_uploader :carrierwave_asset, CarrierwaveUploader
 
   attachment :refile_asset if defined?(Refile)
+
+  enum size_string_enum: {S: 's', M: 'm', L: 'l'}
+  enum size_integer_enum: [:small, :medium, :large]
 end

--- a/spec/dummy_app/app/active_record/field_test.rb
+++ b/spec/dummy_app/app/active_record/field_test.rb
@@ -14,6 +14,8 @@ class FieldTest < ActiveRecord::Base
 
   attachment :refile_asset if defined?(Refile)
 
-  enum size_string_enum: {S: 's', M: 'm', L: 'l'}
-  enum size_integer_enum: [:small, :medium, :large]
+  if ::Rails.version >= '4.1' # enum support was added in Rails 4.1
+    enum size_string_enum: {S: 's', M: 'm', L: 'l'}
+    enum size_integer_enum: [:small, :medium, :large]
+  end
 end

--- a/spec/dummy_app/db/migrate/20171229220713_add_size_enum_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20171229220713_add_size_enum_to_field_tests.rb
@@ -1,0 +1,6 @@
+class AddSizeEnumToFieldTests < MigrationBase
+  def change
+    add_column :field_tests, :size_string_enum,  :string
+    add_column :field_tests, :size_integer_enum, :integer
+  end
+end

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -18,6 +18,47 @@ describe RailsAdmin::AbstractModel do
       end
     end
 
+    context 'on enum' do
+
+      shared_examples "filter on enum" do
+      before do
+        ["S", "M", "L"].each do |size|
+          FactoryGirl.create(:field_test, size_string_enum: size)
+        end
+
+        ["small", "medium", "large"].each do |size|
+          FactoryGirl.create(:field_test, size_integer_enum: size)
+        end
+      end
+        let(:model) { RailsAdmin::AbstractModel.new('FieldTest') }
+        let(:filters) { {enum_field => {'1' => {v: filter_value, o: 'is'}}} }
+        subject(:elements) {  model.all(filters: filters) }
+
+        it 'lists elements by value' do
+          expect(elements.count).to eq(expected_elements_count)
+          expect(elements.map(&enum_field.to_sym)).to all(eq(enum_label))
+        end
+      end
+
+      context "when enum is integer enum" do
+        it_behaves_like "filter on enum" do
+          let(:filter_value) { 0 }
+          let(:enum_field) { "size_integer_enum" }
+          let(:enum_label) { 'small' }
+          let(:expected_elements_count) { 1 }
+        end
+      end
+
+      context "when enum is string enum where label <> value" do
+        it_behaves_like "filter on enum" do
+          let(:filter_value) { 's' }
+          let(:enum_field) { "size_string_enum" }
+          let(:enum_label) { 'S' }
+          let(:expected_elements_count) { 1 }
+        end
+      end
+    end
+
     context 'on dates with :en locale' do
       before do
         [Date.new(2012, 1, 1), Date.new(2012, 1, 2), Date.new(2012, 1, 3), Date.new(2012, 1, 4)].each do |date|

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -18,7 +18,7 @@ describe RailsAdmin::AbstractModel do
       end
     end
 
-    context 'on enum' do
+    context 'on ActiveRecord native enum' do
       shared_examples "filter on enum" do
         before do
           ["S", "M", "L"].each do |size|
@@ -56,7 +56,7 @@ describe RailsAdmin::AbstractModel do
           let(:expected_elements_count) { 1 }
         end
       end
-    end
+    end if CI_ORM == :active_record && ::Rails.version >= '4.1'
 
     context 'on dates with :en locale' do
       before do

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -19,17 +19,16 @@ describe RailsAdmin::AbstractModel do
     end
 
     context 'on enum' do
-
       shared_examples "filter on enum" do
-      before do
-        ["S", "M", "L"].each do |size|
-          FactoryGirl.create(:field_test, size_string_enum: size)
-        end
+        before do
+          ["S", "M", "L"].each do |size|
+            FactoryGirl.create(:field_test, size_string_enum: size)
+          end
 
-        ["small", "medium", "large"].each do |size|
-          FactoryGirl.create(:field_test, size_integer_enum: size)
+          ["small", "medium", "large"].each do |size|
+            FactoryGirl.create(:field_test, size_integer_enum: size)
+          end
         end
-      end
         let(:model) { RailsAdmin::AbstractModel.new('FieldTest') }
         let(:filters) { {enum_field => {'1' => {v: filter_value, o: 'is'}}} }
         subject(:elements) {  model.all(filters: filters) }


### PR DESCRIPTION
Refactored code to remove unnecessary calls to `parse_value`.
Which were affecting filter by enum (rails >= 5.0):
If enum defined like
```
enum size: { L: 'l', S: 's' }
```
Due to multiple calls, the chain when filtering by size is following:
```
parse_value("l") => "L"
parse_value("L") => nil
```
Which leads to non working filtering.
NOTE: `parse_value` returns correct result in both cases above