### PR TITLE
Fix json field tag <pre> in edit form

### DIFF
--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -10,9 +10,11 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(:jsonb, self)
 
           register_instance_option :formatted_value do
-            if value.present?
-              bindings[:view].content_tag(:pre) { JSON.pretty_generate(value) }.html_safe
-            end
+            value.present? ? JSON.pretty_generate(value) : nil
+          end
+
+          register_instance_option :pretty_value do
+            bindings[:view].content_tag(:pre) { formatted_value }.html_safe
           end
 
           def parse_value(value)

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -2,6 +2,55 @@ require 'spec_helper'
 
 describe RailsAdmin::Config::Fields::Types::Json do
   let(:field) { RailsAdmin.config(FieldTest).fields.detect { |f| f.name == :json_field } }
+  let(:object) { FieldTest.new }
+  let(:bindings) do
+    {
+      object: object,
+      view: ApplicationController.new.view_context,
+    }
+  end
+
+  describe '#formatted_value' do
+    before do
+      RailsAdmin.config do |config|
+        config.model FieldTest do
+          field :json_field, :json
+        end
+      end
+    end
+
+    it 'retuns correct value' do
+      allow(object).to receive(:json_field) { {sample_key: "sample_value"} }
+      actual = field.with(bindings).formatted_value
+      expected = [
+        "{",
+        "  \"sample_key\": \"sample_value\"",
+        "}",
+      ].join("\n")
+      expect(actual).to eq(expected)
+    end
+  end
+
+  describe '#pretty_value' do
+    before do
+      RailsAdmin.config do |config|
+        config.model FieldTest do
+          field :json_field, :json
+        end
+      end
+    end
+
+    it 'retuns correct value' do
+      allow(object).to receive(:json_field) { {sample_key: "sample_value"} }
+      actual = field.with(bindings).pretty_value
+      expected = [
+        "<pre>{",
+        "  &quot;sample_key&quot;: &quot;sample_value&quot;",
+        "}</pre>",
+      ].join("\n")
+      expect(actual).to eq(expected)
+    end
+  end
 
   describe '#parse_input' do
     before :each do


### PR DESCRIPTION
### Overview

Fixed redundant tag `pre` in edit form.