### PR TITLE
Rails 5: Corretly populate enum fields in form

### DIFF
--- a/lib/rails_admin/config/fields/factories/enum.rb
+++ b/lib/rails_admin/config/fields/factories/enum.rb
@@ -7,13 +7,13 @@ RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
   method_name = "#{properties.name}_enum"
 
   # NOTICE: _method_name could be `to_enum` and this method defined in Object.
-  if !Object.respond_to?(method_name) && \
+  if model.respond_to?(:defined_enums) && model.defined_enums[properties.name.to_s]
+    fields << RailsAdmin::Config::Fields::Types::ActiveRecordEnum.new(parent, properties.name, properties)
+    true
+  elsif !Object.respond_to?(method_name) && \
      (model.respond_to?(method_name) || \
          model.method_defined?(method_name))
     fields << RailsAdmin::Config::Fields::Types::Enum.new(parent, properties.name, properties)
-    true
-  elsif model.respond_to?(:defined_enums) && model.defined_enums[properties.name.to_s]
-    fields << RailsAdmin::Config::Fields::Types::ActiveRecordEnum.new(parent, properties.name, properties)
     true
   else
     false


### PR DESCRIPTION
Hi, I'm working on upgrading my application to Rails 5 and I've found an issue with enum fields. I haven't seen it reported anywhere which I find a bit surprising, so maybe there's something I'm doing wrong. In case it is a confirmed bug, I'm attaching patch that solved this problem for me.

The description is very long, there's a TLDR in the end.

## Problem

When I edit a record that has an enum field, the value of this field is not properly populated in the form. Instead it's always empty.

## Findings

(I'll use `status` as name of the field for examples.)
There are 2 main findings that cause this problem:

1. The enum field is not correctly recognized as `ActiveRecordEnum`, because the following code returns true for enum I use in my AR class:

```
if !Object.respond_to?(method_name) && \
   (model.respond_to?(method_name) || \
       model.method_defined?(method_name))
  fields << RailsAdmin::Config::Fields::Types::Enum.new(parent, properties.name, properties)
  true
```
Basically the `model.method_defined(:status_enum)` part returns `true`

2. Rails 5 changes the way enum fields behave when we call `safe_send` method.

Rails 4.2.6 -> `my_model.safe_send(:status) # => 0`
Rails 5.0.6 -> `my_model.safe_send(:status) # => "active"`

This seems to be related to introducing a wrapper around the enum fields (previously the `safe_send` was almost directly fetching value from the database, so for integer columns it returned a number), but I'm digressing.

Now, because my `status` field is of `Enum` type (and not `ActiveRecordEnum`) and because `safe_send(:status)` returns a string, a following thing happens. The code below that renders `select` field for enum:

```
= form.select field.method_name, field.enum, { include_blank: true }.reverse_merge({ selected: field.form_value })
```

is executed with following values:

```
= form.select :status, [[0, "active"], [1, "inactive"]], {include_blank: true}.reverse_merge({selected: "active"})
```

So the values of the option tags are numeric, but selected value is a string, and that's why none of the options gets `selected` attribute on its tag. The correct way is either to have `{selected: 0}` or have the 2nd argument replaced with `{"active" => 0, "inactive" => 1}`.

## Solution

The solution is to have the enum field being correctly recognized as `ActiveRecordEnum`. To do that, I swapped the order in the enum factory. Now it's checking for `ActiveRecordEnum` type first and only then for generic `Enum`.

## TL;DR

Enum field is not recognized as `ActiveRecordEnum` field. Despite this, it works correctly for Rails 4.x. Due to changes in Rails 5.0 it does not work correctly anymore. The fix is to make the enum field being correctly recognized as `ActiveRecordEnum`