### PR TITLE
Fixed displaying empty json in edit form

### DIFF
--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -10,7 +10,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(:jsonb, self)
 
           register_instance_option :formatted_value do
-            value.present? ? JSON.pretty_generate(value) : nil
+            value ? JSON.pretty_generate(value) : nil
           end
 
           register_instance_option :pretty_value do

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -19,6 +19,12 @@ describe RailsAdmin::Config::Fields::Types::Json do
       end
     end
 
+    it 'returns correct value for empty json' do
+      allow(object).to receive(:json_field) { {} }
+      actual = field.with(bindings).formatted_value
+      expect(actual).to eq("{\n}")
+    end
+
     it 'retuns correct value' do
       allow(object).to receive(:json_field) { {sample_key: "sample_value"} }
       actual = field.with(bindings).formatted_value


### PR DESCRIPTION
## The problem

I have empty json saved in database (not `null`, just `{}`)
I want to edit my record in RailsAdmin

**What I see**: the json field is empty
**What I should see**: field should display `{}` instead

## The solution

Currently we check whether to display json based on `value.present?`, which returns `false` for empty json. Instead we should just check `value`