### PR TITLE
Escape filter values to prevent XSS.

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -58,7 +58,7 @@ module RailsAdmin
 
     def ordered_filter_string
       @ordered_filter_string ||= ordered_filters.map do |duplet|
-        options = {index: duplet[0]}
+        options = {index: /^\d+$/ === duplet[0].to_s.strip ? duplet[0] : escape_once(duplet[0])}
         filter_for_field = duplet[1]
         filter_name = filter_for_field.keys.first
         filter_hash = filter_for_field.values.first
@@ -71,12 +71,15 @@ module RailsAdmin
         when :date, :datetime, :time
           options[:datetimepicker_format] = field.parser.to_momentjs
         end
+
         options[:label] = field.label
         options[:name]  = field.name
         options[:type]  = field.type
-        options[:value] = filter_hash['v']
+        options[:value] = if v = filter_hash['v']
+                            v.respond_to?(:map) ? v.map { |i| escape_once(i) } : escape_once(v)
+                          end
         options[:label] = field.label
-        options[:operator] = filter_hash['o']
+        options[:operator] = filter_hash['o'] ? escape_once(filter_hash['o']) : nil
         %{$.filters.append(#{options.to_json});}
       end.join("\n").html_safe if ordered_filters
     end

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -316,6 +316,36 @@ describe 'RailsAdmin Basic List', type: :request do
     end
   end
 
+  describe 'GET /admin/player with requested filters' do
+    it 'should escape filter parameters' do
+      xss = '"><script>alert(1)</script>'
+      escaped = ERB::Util.html_escape_once(xss)
+
+      get index_path(model_name: 'player', f: {name: {"#{xss}" => {o: xss, v: xss}},
+                                               id: {'2' => {o: 'between', v: [xss, xss, xss]}}})
+
+      options = {
+        index: escaped,
+        label: 'Name',
+        name: 'name',
+        type: 'string',
+        value: escaped,
+        operator: escaped,
+      }
+      expect(response.body).to include("$.filters.append(#{options.to_json});")
+
+      options = {
+        index: '2',
+        label: 'Id',
+        name: 'id',
+        type: 'integer',
+        value: [escaped, escaped, escaped],
+        operator: 'between',
+      }
+      expect(response.body).to include("$.filters.append(#{options.to_json});")
+    end
+  end
+
   describe 'GET /admin/player with 2 objects' do
     before do
       @players = FactoryGirl.create_list(:player, 2)


### PR DESCRIPTION
Escape `index`, `value` and `operator` parameters for filters, which are rendered from JSON on the client side.

Related to #2985 and #2894