### PR TITLE
don't use like for 'is_exactly' queries

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -225,29 +225,13 @@ module RailsAdmin
         def build_statement_for_string_or_text
           return if @value.blank?
 
-          unless ['postgresql', 'postgis'].include? ar_adapter
-            @value = @value.mb_chars.downcase
-          end
+          @value = @value.mb_chars.downcase unless @operator.in?(%w(is =))
 
-          @value = begin
-            case @operator
-            when 'default', 'like'
-              "%#{@value}%"
-            when 'starts_with'
-              "#{@value}%"
-            when 'ends_with'
-              "%#{@value}"
-            when 'is', '='
-              @value
-            else
-              return
-            end
-          end
-
-          if ['postgresql', 'postgis'].include? ar_adapter
-            ["(#{@column} ILIKE ?)", @value]
-          else
-            ["(LOWER(#{@column}) LIKE ?)", @value]
+          case @operator
+          when 'default', 'like' then ["(LOWER(#{@column}) LIKE ?)", "%#{@value}%"]
+          when 'starts_with'     then ["(LOWER(#{@column}) LIKE ?)", "#{@value}%"]
+          when 'ends_with'       then ["(LOWER(#{@column}) LIKE ?)", "%#{@value}"]
+          when 'is', '='         then ["(#{@column} = ?)", @value]
           end
         end
 

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -208,7 +208,7 @@ describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
         expect(build_statement(:string, 'foo', 'like')).to eq([@like, '%foo%'])
         expect(build_statement(:string, 'foo', 'starts_with')).to eq([@like, 'foo%'])
         expect(build_statement(:string, 'foo', 'ends_with')).to eq([@like, '%foo'])
-        expect(build_statement(:string, 'foo', 'is')).to eq([@like, 'foo'])
+        expect(build_statement(:string, 'foo', 'is')).to eq(["(field = ?)", 'foo'])
       end
 
       it 'performs case-insensitive searches' do


### PR DESCRIPTION
This PR solves issue #1819 so that when filtering for string fields the LIKE operator is not used anymore if the filter is 'is_exactly'.

