### PR TITLE
Allow to customize forgery protection settings

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -11,7 +11,7 @@ module RailsAdmin
   end
 
   class ApplicationController < Config.parent_controller.constantize
-    protect_from_forgery with: :exception
+    protect_from_forgery(Config.forgery_protection_settings)
 
     before_action :_authenticate!
     before_action :_authorize!

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -62,6 +62,10 @@ module RailsAdmin
       # set parent controller
       attr_accessor :parent_controller
 
+      # set settings for `protect_from_forgery` method
+      # By default, it raises exception upon invalid CSRF tokens
+      attr_accessor :forgery_protection_settings
+
       # Stores model configuration objects in a hash identified by model's class
       # name.
       #
@@ -288,6 +292,7 @@ module RailsAdmin
         @navigation_static_links = {}
         @navigation_static_label = nil
         @parent_controller = '::ActionController::Base'
+        @forgery_protection_settings = {with: :exception}
         RailsAdmin::Config::Actions.reset
       end
 

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -274,6 +274,19 @@ describe RailsAdmin::Config do
     end
   end
 
+  describe '.forgery_protection_settings' do
+    it 'uses with: :exception by default' do
+      expect(RailsAdmin.config.forgery_protection_settings).to eq(with: :exception)
+    end
+
+    it 'allows to customize settings' do
+      RailsAdmin.config do |config|
+        config.forgery_protection_settings = {with: :null_session}
+      end
+      expect(RailsAdmin.config.forgery_protection_settings).to eq(with: :null_session)
+    end
+  end
+
   describe '.model' do
     let(:fields) { described_class.model(Team).fields }
     before do


### PR DESCRIPTION
Currently `protect_from_forgery` is always called with `with: :exception`,
which might becausing problems in certain applications.

This commit enables configuration for `protect_from_forgery` method,
and keeps `with: :exception` as default settings