### PR TITLE
Avoid duplication of filters on back

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -157,7 +157,11 @@
           break;
       }
 
+      var filterContainerId = field_name + '-' + index + '-filter-container';
+      $('p#' + filterContainerId).remove();
+
       var $content = $('<p>')
+        .attr('id', filterContainerId)
         .addClass('filter form-search')
         .append(
           $('<span class="label label-info form-label"></span>')


### PR DESCRIPTION
Bug: filters are duplicated when using back button
Repro steps:
Using Chrome, visit a list page, apply a filter, click into an element, click back button
Using these steps, I see a duplicated filter. RailsAdmin is appending the filters regardless
of whether or not they are there.

This fixes that by adding an id to each filter based on the name and index.
Before appending, it removes any filters with that id.

I haven't been able to figure out how to write specs for this. Any assistance would be appreciated.