### PR TITLE
Fix "can't modify frozen array" exception under certain conditions

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -130,7 +130,7 @@ module RailsAdmin
           @_ro_fields = @_fields = RailsAdmin::Config::Fields.factory(self)
         else
           # parent is RailsAdmin::Config::Model, recursion is on Section's classes
-          @_ro_fields ||= parent.send(self.class.superclass.to_s.underscore.split('/').last)._fields(true).freeze
+          @_ro_fields ||= parent.send(self.class.superclass.to_s.underscore.split('/').last)._fields(true).clone.freeze
         end
         readonly ? @_ro_fields : (@_fields ||= @_ro_fields.collect(&:clone))
       end

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -327,6 +327,37 @@ describe RailsAdmin::Config do
       end
     end
   end
+
+  describe "field types code reloading" do
+    let(:config) { described_class.model(Team) }
+    let(:fields) { described_class.model(Team).edit.fields }
+
+    let(:team_config) {
+      Proc.new {
+        field :id
+        field :wins, :boolean
+      }
+    }
+    let(:team_config2) {
+      Proc.new {
+        field :wins, :toggle
+      }
+    }
+
+    it "allows code reloading" do
+      Team.send(:rails_admin, &team_config)
+
+      # This simulates the way RailsAdmin really does it
+      config.edit.send(:_fields, true)
+
+      class RailsAdmin::Config::Fields::Types::Toggle < RailsAdmin::Config::Fields::Base
+        RailsAdmin::Config::Fields::Types::register(self)
+      end
+      Team.send(:rails_admin, &team_config2)
+      expect(fields.map(&:name)).to match_array %i(id wins)
+    end
+  end
+
 end
 
 module ExampleModule

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -332,17 +332,17 @@ describe RailsAdmin::Config do
     let(:config) { described_class.model(Team) }
     let(:fields) { described_class.model(Team).edit.fields }
 
-    let(:team_config) {
-      Proc.new {
+    let(:team_config) do
+      proc do
         field :id
         field :wins, :boolean
-      }
-    }
-    let(:team_config2) {
-      Proc.new {
+      end
+    end
+    let(:team_config2) do
+      proc do
         field :wins, :toggle
-      }
-    }
+      end
+    end
 
     it "allows code reloading" do
       Team.send(:rails_admin, &team_config)
@@ -350,14 +350,21 @@ describe RailsAdmin::Config do
       # This simulates the way RailsAdmin really does it
       config.edit.send(:_fields, true)
 
-      class RailsAdmin::Config::Fields::Types::Toggle < RailsAdmin::Config::Fields::Base
-        RailsAdmin::Config::Fields::Types::register(self)
+      module RailsAdmin
+        module Config
+          module Fields
+            module Types
+              class Toggle < RailsAdmin::Config::Fields::Base
+                RailsAdmin::Config::Fields::Types.register(self)
+              end
+            end
+          end
+        end
       end
       Team.send(:rails_admin, &team_config2)
       expect(fields.map(&:name)).to match_array %i(id wins)
     end
   end
-
 end
 
 module ExampleModule


### PR DESCRIPTION
This fixes "can't modify frozen array" exception which occurs for me in development in many real-world apps.

It happens when @_fields is returned from HasFields#fields and then it is being frozen when assigning it to @_ro_fields.

The spec included is as close as I could get it to my use-case (real app does not need to add a new field type, any change to code that causes my app to reload triggers this exception)
