### PR TITLE
fixes issue #2919

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -26,6 +26,11 @@ module RailsAdmin
     initializer 'RailsAdmin setup middlewares' do |app|
       app.config.middleware.use ActionDispatch::Flash
       app.config.middleware.use Rack::Pjax
+
+      app.config.session_store :cookie_store
+      app.config.middleware.use ActionDispatch::Cookies
+      app.config.middleware.use ActionDispatch::Session::CookieStore, app.config.session_options
+      app.config.middleware.use Rack::MethodOverride
     end
 
     rake_tasks do


### PR DESCRIPTION
Add missing cookie middleware when rails is used in api mode

I am not entirely sure if this is the correct way to go about this. My rails engine knowledge is limited. Will this also add these middlewares to the main application or _just_ this engine (rails_admin) ?