### PR TITLE
Add possibility to have custom search on model

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ end
 
 Details: [Models](https://github.com/sferik/rails_admin/wiki/Models), [Groups](https://github.com/sferik/rails_admin/wiki/Groups), [Fields](https://github.com/sferik/rails_admin/wiki/Fields)
 
+
+### Custom model search using pg_search
+```ruby
+class Ball < ActiveRecord::Base
+  include PgSearch
+  validates :name, presence: true
+  belongs_to :player
+
+  pg_search_scope :rails_admin_search,
+    :against => [:id, :name],
+    :associated_against => {
+      player: [:id, :name]
+    },
+    using: {
+      tsearch: {any_word: true,},
+      trigram: {threshold: 0.1}
+    }
+end
+```
+
+
 ## Documentation
 https://github.com/sferik/rails_admin/wiki
 

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -32,11 +32,9 @@ module RailsAdmin
         scope = scope.where(primary_key => options[:bulk_ids]) if options[:bulk_ids]
 
         if options[:query]
-          begin
-            # if you're using pg_search, the method is not defined
-            # eventhough it's there
-            scope = scope.rails_admin_search(options[:query])
-          rescue
+          if self.config.search_scope
+            scope = scope.send(self.config.search_scope, options[:query])
+          else
             scope = query_scope(scope, options[:query])
           end
         end

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -30,7 +30,17 @@ module RailsAdmin
         scope = scope.includes(options[:include]) if options[:include]
         scope = scope.limit(options[:limit]) if options[:limit]
         scope = scope.where(primary_key => options[:bulk_ids]) if options[:bulk_ids]
-        scope = query_scope(scope, options[:query]) if options[:query]
+
+        if options[:query]
+          begin
+            # if you're using pg_search, the method is not defined
+            # eventhough it's there
+            scope = scope.rails_admin_search(options[:query])
+          rescue
+            scope = query_scope(scope, options[:query])
+          end
+        end
+
         scope = filter_scope(scope, options[:filters]) if options[:filters]
         if options[:page] && options[:per]
           scope = scope.send(Kaminari.config.page_method_name, options[:page]).per(options[:per])

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -76,6 +76,10 @@ module RailsAdmin
         0
       end
 
+      register_instance_option :search_scope do
+        @search_scope ||= nil
+      end
+
       # parent node in navigation/breadcrumb
       register_instance_option :parent do
         @parent_model ||= begin


### PR DESCRIPTION
You can now add a scope `rails_admin_search` that allows you to override the default search method. This will be useful for people who wants to search with joined model;

For example, if you're using `globalize` and the model's `name` column is translated, currently it fails to search for the correct one, but with `pg_search` and some minor basic querying with `pg_search` you'll be able to find your needed result.

Example of usage:
```ruby
  pg_search_scope :rails_admin_search,
    :against => [:id],
    :associated_against => {
      translations: :name
    },
    using: {
      tsearch: {any_word: true,},
      trigram: {threshold: 0.1}
    }
```