### PR TITLE
Bump jquery-ui-rails dependency to ~> 6.0

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'font-awesome-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'haml', '>= 4.0', '< 6'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
-  spec.add_dependency 'jquery-ui-rails', ['>= 5.0', '< 7']
+  spec.add_dependency 'jquery-ui-rails', ['>= 6.0', '< 7']
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'
   spec.add_dependency 'nested_form', '~> 0.3'
   spec.add_dependency 'rack-pjax', '>= 0.7'


### PR DESCRIPTION
jquery-ui-rails starting at 6.0.0 fixes broken ui-autocomplete (drop-down inputs)
Related issue: https://github.com/sferik/rails_admin/issues/2951