### PR TITLE
use asset_path for codemirror asset links

### DIFF
--- a/app/views/rails_admin/main/_form_file_upload.html.haml
+++ b/app/views/rails_admin/main/_form_file_upload.html.haml
@@ -1,4 +1,4 @@
-- file = form.object.send(field.method_name).presence
+- file = form.object.send(field.method_name).send(field.presence_method)
 
 .toggle{style: ('display:none;' if file && field.delete_method && form.object.send(field.delete_method) == '1')}
   - if value = field.pretty_value

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -1,0 +1,45 @@
+require 'rails_admin/config/fields/types/file_upload'
+
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class ActiveStorage < RailsAdmin::Config::Fields::Types::FileUpload
+          RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :thumb_method do
+            { resize: '100x100>' }
+          end
+
+          register_instance_option :delete_method do
+            "remove_#{name}" if bindings[:object].respond_to?("remove_#{name}")
+          end
+
+          register_instance_option :presence_method do
+            # `attachment` returns Attachment instance or `nil` if not attached
+            :attachment
+          end
+
+          register_instance_option :image? do
+            if value.attached?
+              value.filename.to_s.split('.').last =~ /jpg|jpeg|png|gif|svg/i
+            end
+          end
+
+          def resource_url(thumb = false)
+            return nil unless value.attached?
+            v = bindings[:view]
+            if thumb && value.variable?
+              variant = value.variant(thumb)
+              Rails.application.routes.url_helpers.rails_blob_representation_path(
+                variant.blob.signed_id, variant.variation.key, variant.blob.filename, only_path: true
+              )
+            else
+              Rails.application.routes.url_helpers.rails_blob_path(value, only_path: true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/config/fields/types/all.rb
+++ b/lib/rails_admin/config/fields/types/all.rb
@@ -1,4 +1,5 @@
 require 'rails_admin/config/fields/types/active_record_enum'
+require 'rails_admin/config/fields/types/active_storage'
 require 'rails_admin/config/fields/types/belongs_to_association'
 require 'rails_admin/config/fields/types/boolean'
 require 'rails_admin/config/fields/types/bson_object_id'

--- a/lib/rails_admin/config/fields/types/code_mirror.rb
+++ b/lib/rails_admin/config/fields/types/code_mirror.rb
@@ -19,19 +19,19 @@ module RailsAdmin
           # Pass the location of the theme and mode for Codemirror
           register_instance_option :assets do
             {
-              mode: '/assets/codemirror/modes/css.js',
-              theme: '/assets/codemirror/themes/night.css',
+              mode: ::ActionController::Base.helpers.asset_path('codemirror/modes/css.js'),
+              theme: ::ActionController::Base.helpers.asset_path('codemirror/themes/night.css'),
             }
           end
 
           # Use this if you want to point to a cloud instances of CodeMirror
           register_instance_option :js_location do
-            '/assets/codemirror.js'
+            ::ActionController::Base.helpers.asset_path('codemirror.js')
           end
 
           # Use this if you want to point to a cloud instances of CodeMirror
           register_instance_option :css_location do
-            '/assets/codemirror.css'
+            ::ActionController::Base.helpers.asset_path('codemirror.css')
           end
 
           register_instance_option :partial do

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -23,12 +23,16 @@ module RailsAdmin
             nil
           end
 
+          register_instance_option :presence_method do
+            :presence
+          end
+
           register_instance_option :export_value do
             resource_url.to_s
           end
 
           register_instance_option :pretty_value do
-            if value.presence
+            if value.send(presence_method)
               v = bindings[:view]
               url = resource_url
               if image


### PR DESCRIPTION
Asset links without fingerprint are hard to handle in an normal rails production environment. So, hope, that this solution is good enough.