### PR TITLE
Cancancan adapter is registered as cancan

### DIFF
--- a/lib/rails_admin/extensions/cancancan.rb
+++ b/lib/rails_admin/extensions/cancancan.rb
@@ -1,3 +1,3 @@
 require 'rails_admin/extensions/cancancan/authorization_adapter'
 
-RailsAdmin.add_extension(:cancan, RailsAdmin::Extensions::CanCanCan, authorization: true)
+RailsAdmin.add_extension(:cancancan, RailsAdmin::Extensions::CanCanCan, authorization: true)


### PR DESCRIPTION
Currently, cancancan cannot be set in ```config.authorize_with``` because it's registered with name ```cancan``` - same as ```cancan```

I am unsure why it's like this but it seems not to be intended.