### PR TITLE
code_reload

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -304,6 +304,14 @@ module RailsAdmin
         @registry.delete(key)
       end
 
+      # Reset all models configuration
+      # Used to clear all configurations when reloading code in development.
+      # @see RailsAdmin::Engine
+      # @see RailsAdmin::Config.registry
+      def reset_all_models
+        @registry = {}
+      end
+
       # Get all models that are configured as visible sorted by their weight and label.
       #
       # @see RailsAdmin::Config::Hideable

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -33,9 +33,13 @@ module RailsAdmin
     end
 
     initializer 'RailsAdmin reload config in development' do
-      unless Rails.application.config.cache_classes
-        ActiveSupport::Reloader.before_class_unload do |cl|
-          RailsAdmin::Config.reset_all_models
+      if Rails.application.config.cache_classes
+        if defined?(ActiveSupport::Reloader)
+          ActiveSupport::Reloader.before_class_unload do
+            RailsAdmin::Config.reset_all_models
+          end
+          # else
+          # For Rails 4 not implemented
         end
       end
     end

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -32,6 +32,14 @@ module RailsAdmin
       app.config.middleware.use Rack::Pjax
     end
 
+    initializer 'RailsAdmin reload config in development' do
+      unless Rails.application.config.cache_classes
+        ActiveSupport::Reloader.before_class_unload do |cl|
+          RailsAdmin::Config.reset_all_models
+        end
+      end
+    end
+
     rake_tasks do
       Dir[File.join(File.dirname(__FILE__), '../tasks/*.rake')].each { |f| load f }
     end

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -381,7 +381,9 @@ describe RailsAdmin::Config do
           i.name == "RailsAdmin reload config in development"
         end.first.block.call
         if defined?(ActiveSupport::Reloader)
-          ActiveSupport::Reloader.new.tap(&:class_unload!)
+          Rails.application.executor.wrap do
+            ActiveSupport::Reloader.new.tap(&:class_unload!).complete!
+          end
           # else
           # for Rails 4 not imlemented yet
         end


### PR DESCRIPTION
Fix reloading models when code changes. The problem is connected with pull request [#2999](https://github.com/sferik/rails_admin/pull/2999)
There the problem was solved partially. It fixed the "can't modify frozen array" exception on reload, but versions of models were still old.