### PR TITLE
Use 1 as argument for count method instead of `:all`, as it is going to return the non …

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -40,7 +40,7 @@ module RailsAdmin
       end
 
       def count(options = {}, scope = nil)
-        all(options.merge(limit: false, page: false), scope).count(:all)
+        all(options.merge(limit: false, page: false), scope).count(1)
       end
 
       def destroy(objects)


### PR DESCRIPTION
…zero rows anyhow and reduce the overhead