### PR TITLE
Update Readme with supported Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This library aims to support and is [tested against][travis] the following Ruby 
 * Ruby 2.1
 * Ruby 2.2
 * Ruby 2.3
+* Ruby 2.4
+* Ruby 2.5
 * [Rubinius][]
 * [JRuby][]
 


### PR DESCRIPTION
Looking on the Travis matrix and [build](https://travis-ci.org/sferik/rails_admin) in Travis rails_admin is supported for Ruby 2.4 and 2.5 too.