### PR TITLE
Fix overriding session's option when using full-stack app.

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -26,7 +26,7 @@ module RailsAdmin
     initializer 'RailsAdmin setup middlewares' do |app|
       app.config.middleware.use ActionDispatch::Cookies
       app.config.middleware.use ActionDispatch::Flash
-      if app.config.api_only
+      if app.config.respond_to?(:api_only) && app.config.api_only
         app.config.session_store :cookie_store
         app.config.middleware.use ActionDispatch::Session::CookieStore, app.config.session_options
       end

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -24,10 +24,12 @@ module RailsAdmin
     end
 
     initializer 'RailsAdmin setup middlewares' do |app|
-      app.config.session_store :cookie_store
       app.config.middleware.use ActionDispatch::Cookies
       app.config.middleware.use ActionDispatch::Flash
-      app.config.middleware.use ActionDispatch::Session::CookieStore, app.config.session_options
+      if app.config.api_only
+        app.config.session_store :cookie_store
+        app.config.middleware.use ActionDispatch::Session::CookieStore, app.config.session_options
+      end
       app.config.middleware.use Rack::MethodOverride
       app.config.middleware.use Rack::Pjax
     end


### PR DESCRIPTION
If developer is not using api mode, session's middleware configuration is up to a developer.
Otherwise it will overwrite configuration.

Fixes #3048 