### PR TITLE
Fix export crash for models with JSON field

### DIFF
--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -17,6 +17,10 @@ module RailsAdmin
             bindings[:view].content_tag(:pre) { formatted_value }.html_safe
           end
 
+          register_instance_option :export_value do
+            formatted_value
+          end
+
           def parse_value(value)
             value.present? ? JSON.parse(value) : nil
           end

--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -23,6 +23,8 @@ module RailsAdmin
 
           def parse_value(value)
             value.present? ? JSON.parse(value) : nil
+          rescue JSON::ParserError
+            nil
           end
 
           def parse_input(params)

--- a/spec/integration/basic/export/rails_admin_basic_export_spec.rb
+++ b/spec/integration/basic/export/rails_admin_basic_export_spec.rb
@@ -37,6 +37,12 @@ describe 'RailsAdmin Export', type: :request do
               "#{value} exported"
             end
           end
+
+          field :json_field, :json do
+            formatted_value do
+              '{}'
+            end
+          end
         end
       end
 
@@ -46,7 +52,7 @@ describe 'RailsAdmin Export', type: :request do
       click_button 'Export to csv'
       csv = CSV.parse page.driver.response.body.force_encoding('utf-8') # comes through as us-ascii on some platforms
       expect(csv[0]).to match_array ['Id', 'Created at', 'Updated at', 'Deleted at', 'Name', 'Position',
-                                     'Number', 'Retired', 'Injured', 'Born on', 'Notes', 'Suspended', 'Formation', 'Id [Team]', 'Created at [Team]',
+                                     'Number', 'Retired', 'Injured', 'Born on', 'Notes', 'Suspended', 'Formation', 'Json field', 'Id [Team]', 'Created at [Team]',
                                      'Updated at [Team]', 'Name [Team]', 'Logo url [Team]', 'Team Manager [Team]', 'Ballpark [Team]',
                                      'Mascot [Team]', 'Founded [Team]', 'Wins [Team]', 'Losses [Team]', 'Win percentage [Team]',
                                      'Revenue [Team]', 'Color [Team]', 'Custom field [Team]', 'Main Sponsor [Team]', 'Id [Draft]', 'Created at [Draft]',

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -36,6 +36,16 @@ describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
     let(:abstract_model) { RailsAdmin::AbstractModel.new('Player') }
 
     before do
+      RailsAdmin.config do |c|
+        c.model Player do
+          include_all_fields
+
+          field :json_field, :json do
+            queryable true
+          end
+        end
+      end
+
       @players = FactoryGirl.create_list(:player, 3) + [
         # Multibyte players
         FactoryGirl.create(:player, name: 'Антоха'),

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -58,6 +58,33 @@ describe RailsAdmin::Config::Fields::Types::Json do
     end
   end
 
+  describe '#export_value' do
+    before do
+      RailsAdmin.config do |config|
+        config.model FieldTest do
+          field :json_field, :json
+        end
+      end
+    end
+
+    it 'returns correct value for empty json' do
+      allow(object).to receive(:json_field) { {} }
+      actual = field.with(bindings).export_value
+      expect(actual).to match(/{\n+}/)
+    end
+
+    it 'returns correct value' do
+      allow(object).to receive(:json_field) { {sample_key: "sample_value"} }
+      actual = field.with(bindings).export_value
+      expected = [
+        "{",
+        "  \"sample_key\": \"sample_value\"",
+        "}",
+      ].join("\n")
+      expect(actual).to eq(expected)
+    end
+  end
+
   describe '#parse_input' do
     before :each do
       RailsAdmin.config do |config|

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -99,8 +99,8 @@ describe RailsAdmin::Config::Fields::Types::Json do
       expect(field.parse_input(json_field: data.to_json)).to eq data
     end
 
-    it 'raise JSON::ParserError with invalid json string' do
-      expect { field.parse_input(json_field: '{{') }.to raise_error(JSON::ParserError)
+    it 'returns nil with invalid json string' do
+      expect(field.parse_input(json_field: '{{')).to be_nil
     end
   end
 


### PR DESCRIPTION
Hi everyone,

I experienced a crash when was exporting a model with a JSON field:

```ruby
NoMethodError:
undefined method `content_tag' for nil:NilClass'
# ./lib/rails_admin/config/fields/types/json.rb:17:in `block in
<class:Json>'
```

Failing lines:

```ruby
# lib/rails_admin/config/fields/types/json.rb
# ...
  register_instance_option :pretty_value do
    bindings[:view].content_tag(:pre) { formatted_value }.html_safe
  end
# ...
```

Apparently `bindings[:view]` is nil within export context.

Here's a proposed fix for that, I specified an `export_value` for json field.

Additionally, another test failed for model querying if JSON field is included, so I suppose it's more practical to return nil instead of raising JSON::ParserError in this case.

Thanks for an awesome product!