### PR TITLE
Avoid using private API of PaperTrail

### DIFF
--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -37,6 +37,16 @@ module RailsAdmin
           created_at: :created_at,
           message: :event,
         }.freeze
+        E_VERSION_MODEL_NOT_SET = <<-EOS.strip_heredoc.freeze
+          Please set up PaperTrail's version model explicitly.
+
+              config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
+
+          If you have configured a model to use a custom version class
+          (https://github.com/paper-trail-gem/paper_trail#6a-custom-version-classes)
+          that configuration will take precedence over what you specify in
+          `audit_with`.
+        EOS
 
         def self.setup
           raise('PaperTrail not found') unless defined?(::PaperTrail)
@@ -59,7 +69,7 @@ module RailsAdmin
           begin
             @version_class = version_class.to_s.constantize
           rescue NameError
-            raise "Please set up Papertrail's version model explicitly. Ex: config.audit_with :paper_trail, 'User', 'PaperTrail::Version'"
+            raise E_VERSION_MODEL_NOT_SET
           end
         end
 
@@ -91,6 +101,7 @@ module RailsAdmin
 
       protected
 
+        # - model - a RailsAdmin::AbstractModel
         def listing_for_model_or_object(model, object, query, sort, sort_reverse, all, page, per_page)
           if sort.present?
             sort = COLUMN_MAPPING[sort.to_sym]
@@ -99,11 +110,10 @@ module RailsAdmin
             sort_reverse = 'true'
           end
 
-          model_name = model.model.name
-
+          ar_model = model.model
           current_page = page.presence || '1'
 
-          versions = version_class_for(model_name).where item_type: model_name
+          versions = version_class_for(ar_model).where item_type: ar_model.name
           versions = versions.where item_id: object.id if object
           versions = versions.where('event LIKE ?', "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == 'true' ? "#{sort} DESC" : sort)
@@ -116,12 +126,14 @@ module RailsAdmin
           paginated_proxies
         end
 
-        def version_class_for(model_name)
-          klass = model_name.constantize.
-                  try(:version_class_name).
-                  try(:constantize)
-
-          klass || @version_class
+        # PT can be configured to use [custom version
+        # classes](https://github.com/paper-trail-gem/paper_trail#6a-custom-version-classes)
+        #
+        # ```ruby
+        # has_paper_trail class_name: 'MyVersion'
+        # ```
+        def version_class_for(model)
+          model.paper_trail_options[:class_name].try(:constantize) || @version_class
         end
       end
     end

--- a/spec/integration/history/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/history/rails_admin_paper_trail_spec.rb
@@ -44,7 +44,13 @@ describe 'RailsAdmin PaperTrail history', active_record: true do
       @user = FactoryBot.create :user
       @paper_trail_test = FactoryBot.create :paper_trail_test
       with_versioning do
-        PaperTrail.whodunnit = @user.id
+        # `PaperTrail.whodunnit` deprecated in PT 9, will be removed in 10.
+        # Use `PaperTrail.request.whodunnit` instead.
+        if PaperTrail.respond_to?(:request)
+          PaperTrail.request.whodunnit = @user.id
+        else
+          PaperTrail.whodunnit = @user.id
+        end
         30.times do |i|
           @paper_trail_test.update!(name: "updated name #{i}")
         end


### PR DESCRIPTION
1. `version_class_name` is private API. Please use `paper_trail_options` instead.
2. Fixes deprecation warning re: PaperTrail.whodunnit