### PR TITLE
Fix field is reseted to default if error happened

### DIFF
--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -23,6 +23,23 @@ module RailsAdmin
         self.class.register_deprecated_instance_option(option_name, replacement_option_name, scope, &custom_error)
       end
 
+    private
+
+      def with_recurring(option_name, value_proc, default_proc)
+        # Track recursive invocation with an instance variable. This prevents run-away recursion
+        # and allows configurations such as
+        # label { "#{label}".upcase }
+        # This will use the default definition when called recursively.
+        if instance_variable_get("@#{option_name}_recurring")
+          instance_eval(&default_proc)
+        else
+          instance_variable_set("@#{option_name}_recurring", true)
+          instance_eval(&value_proc)
+        end
+      ensure
+        instance_variable_set("@#{option_name}_recurring", false)
+      end
+
       module ClassMethods
         # Register an instance option. Instance option is a configuration
         # option that stores its value within an instance variable and is
@@ -51,17 +68,7 @@ module RailsAdmin
               value = instance_variable_get("@#{option_name}_registered")
               case value
               when Proc
-                # Track recursive invocation with an instance variable. This prevents run-away recursion
-                # and allows configurations such as
-                # label { "#{label}".upcase }
-                # This will use the default definition when called recursively.
-                if instance_variable_get("@#{option_name}_recurring")
-                  value = instance_eval(&default)
-                else
-                  instance_variable_set("@#{option_name}_recurring", true)
-                  value = instance_eval(&value)
-                  instance_variable_set("@#{option_name}_recurring", false)
-                end
+                value = with_recurring(option_name, value, default)
               when nil
                 value = instance_eval(&default)
               end

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -63,6 +63,20 @@ describe 'RailsAdmin Config DSL Edit Section', type: :request do
       visit new_path(model_name: 'team')
       expect(find_field('team[color]').value).to eq('black')
     end
+
+    it 'renders custom value next time if error happend' do
+      RailsAdmin.config(Team) do
+        field :name do
+          render do
+            bindings[:object].persisted? ? 'Custom Name' : raise(ZeroDivisionError)
+          end
+        end
+      end
+      expect { visit new_path(model_name: 'team') }.to raise_error(/ZeroDivisionError/)
+      record = FactoryBot.create(:team)
+      visit edit_path(model_name: 'team', id: record.id)
+      expect(page).to have_content('Custom Name')
+    end
   end
 
   describe 'css hooks' do


### PR DESCRIPTION
When error is raised for some object in `instance_eval(&value)` then `instance_variable_set("@#{option_name}_recurring", false)` won't be reset. As a result all other objects (from that model) will have a default value instead of custom value (even if they do not raise an error). 