### PR TITLE
Fix: resolve LGTM errors in this file

### DIFF
--- a/app/assets/javascripts/rails_admin/jquery.pjax.js
+++ b/app/assets/javascripts/rails_admin/jquery.pjax.js
@@ -188,8 +188,6 @@ function pjax(options) {
     xhr.setRequestHeader('X-PJAX', 'true')
     xhr.setRequestHeader('X-PJAX-Container', context.selector)
 
-    var result
-
     if (!fire('pjax:beforeSend', [xhr, settings]))
       return false
 
@@ -437,7 +435,7 @@ function fallbackPjax(options) {
       form.append($('<input>', {type: 'hidden', name: pair[0], value: pair[1]}))
     })
   } else if (typeof data === 'object') {
-    for (key in data)
+    for (var key in data)
       form.append($('<input>', {type: 'hidden', name: key, value: data[key]}))
   }
 


### PR DESCRIPTION
Fix variable declaration and unused variable errors, shown in [LGTM alert snapshot](https://lgtm.com/projects/g/sferik/rails_admin/snapshot/bd6d9c38b770fa2a8bf90e0defacd2d408d52a88/files/app/assets/javascripts/rails_admin/jquery.pjax.js?#xd6448c099a57d00e:1) 

- Remove unused variable `result` on line 191
- Add `var` variable declaration for the `for...in` statement on line 440