### PR TITLE
Switch to sassc-rails as Ruby Sass is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '>= 0.3.14'
-    gem 'sqlite3', '>= 1.3'
+    gem 'sqlite3', '~> 1.3'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'appraisal', '>= 2.0'
 gem 'rails'
 gem 'haml'
 gem 'devise'
+gem 'sassc-rails'
 
 group :active_record do
   gem 'paper_trail'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '>= 0.3.14'
-    gem 'sqlite3', '~> 1.3'
+    gem 'sqlite3', '~> 1.3.0'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :active_record do
 
   platforms :ruby, :mswin, :mingw do
     gem 'mysql2', '>= 0.3.14'
-    gem 'sqlite3', '~> 1.3.0'
+    gem 'sqlite3', '>= 1.3'
   end
 end
 

--- a/gemfiles/cancan.gemfile
+++ b/gemfiles/cancan.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.1.0"
 gem "haml"
 gem "devise", "~> 4.0"
-gem "sass-rails", "~> 5.0"
+gem "sassc-rails"
 
 group :active_record do
   gem "paper_trail"

--- a/gemfiles/cancan.gemfile
+++ b/gemfiles/cancan.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.1.0"
 gem "haml"
 gem "devise", "~> 4.0"
+gem "sass-rails", "~> 5.0"
 gem "sassc-rails"
 
 group :active_record do

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 4.0.0"
 gem "haml"
 gem "devise", ">= 3.2"
+gem "sass-rails", "~> 4.0.3"
 gem "sassc-rails"
 gem "test-unit"
 gem "capybara", ">= 0.8", group: :test

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 4.0.0"
 gem "haml"
 gem "devise", ">= 3.2"
-gem "sass-rails", "~> 4.0.3"
+gem "sassc-rails"
 gem "test-unit"
 gem "capybara", ">= 0.8", group: :test
 gem "kaminari", "~> 0.14"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", ">= 2.0"
 gem "rails", "~> 4.1.0"
 gem "haml"
+gem "sassc-rails"
 gem "devise", ">= 3.2"
 gem "capybara", ">= 0.8", group: :test
 

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 gem "appraisal", ">= 2.0"
 gem "rails", "~> 4.2.0"
 gem "haml"
+gem "sassc-rails"
 gem "devise", ">= 3.4"
-gem "sass-rails", "~> 5.0"
 gem "capybara", ">= 0.8", group: :test
 
 group :active_record do

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -5,8 +5,9 @@ source "https://rubygems.org"
 gem "appraisal", ">= 2.0"
 gem "rails", "~> 4.2.0"
 gem "haml"
-gem "sassc-rails"
 gem "devise", ">= 3.4"
+gem "sass-rails", "~> 5.0"
+gem "sassc-rails"
 gem "capybara", ">= 0.8", group: :test
 
 group :active_record do

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.1.0"
 gem "haml"
 gem "devise", "~> 4.0"
-gem "sass-rails", "~> 5.0"
+gem "sassc-rails"
 
 group :active_record do
   gem "paper_trail", ">= 5.0"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.1.0"
 gem "haml"
 gem "devise", "~> 4.0"
+gem "sass-rails", "~> 5.0"
 gem "sassc-rails"
 
 group :active_record do

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.2.0"
 gem "haml"
 gem "devise", "~> 4.4"
+gem "sass-rails", "~> 5.0"
 gem "sassc-rails"
 
 group :active_record do

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -6,7 +6,7 @@ gem "appraisal", ">= 2.0"
 gem "rails", "~> 5.2.0"
 gem "haml"
 gem "devise", "~> 4.4"
-gem "sass-rails", "~> 5.0"
+gem "sassc-rails"
 
 group :active_record do
   gem "paper_trail", ">= 5.0"

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-pjax', '>= 0.7'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']
   spec.add_dependency 'remotipart', '~> 1.3'
+  spec.add_dependency 'sass-rails', ['>= 4.0', '< 6']
   spec.add_dependency 'sassc-rails', ['>= 1.3', '< 2']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ['Erik Michaels-Ober', 'Bogdan Gaza', 'Petteri Kaapa', 'Benoit Benezech', 'Mitsuhiro Shibuya']

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack-pjax', '>= 0.7'
   spec.add_dependency 'rails', ['>= 4.0', '< 6']
   spec.add_dependency 'remotipart', '~> 1.3'
-  spec.add_dependency 'sass-rails', ['>= 4.0', '< 6']
+  spec.add_dependency 'sassc-rails', ['>= 1.3', '< 2']
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ['Erik Michaels-Ober', 'Bogdan Gaza', 'Petteri Kaapa', 'Benoit Benezech', 'Mitsuhiro Shibuya']
   spec.description = 'RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data.'


### PR DESCRIPTION
https://github.com/sass/ruby-sass Ruby Sass is deprecated and will be unmaintained as of 26 March 2019.

This switches the `sass-rails` gem over to `sassc-rails` ( https://github.com/sass/sassc-rails ) .