### PR TITLE
Fix typo

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -54,7 +54,7 @@ module RailsAdmin
         configs << "config.middleware.use #{app.config.session_store.try(:name) || 'ActionDispatch::Session::CookieStore'}, #{app.config.session_options}" unless has_session_store
         raise <<-EOM
 Required middlewares for RailsAdmin are not added
-To fix tihs, add
+To fix this, add
 
   #{configs.join("\n  ")}
 


### PR DESCRIPTION
I noticed there was a typo in an error message when updating the gem. 
This PR fixed it. Please review when it's convenient for you.