### PR TITLE
const RailsAdmin::Adapters::ActiveRecord missing every time I initial…

### DIFF
--- a/lib/rails_admin/config/fields/factories/active_storage.rb
+++ b/lib/rails_admin/config/fields/factories/active_storage.rb
@@ -1,6 +1,7 @@
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'
+require 'rails_admin/adapters/active_record/association'
 
 RailsAdmin::Config::Fields.register_factory do |parent, properties, fields|
   if defined?(::ActiveStorage) && properties.is_a?(RailsAdmin::Adapters::ActiveRecord::Association) && (match = /\A(.+)_attachments?\Z/.match properties.name) && properties.klass.to_s == 'ActiveStorage::Attachment'


### PR DESCRIPTION
Every time I enter on a page which has a model with associations on Mongoid, I always receive a const `RailsAdmin::Adapters::ActiveRecord` is missing error, so digging the code I found there isn't any require for this for file `rails_admin/adapters/active_record/association`, after I require the file the model started loading properly.

my specs:

Rails: 5.2.1
Ruby: 2.5.3p105

This is my models
```ruby
class PatternConfig
  include Mongoid::Document

  field :patern_name, type: String
  field :token,       type: String
  field :service,     type: String

  index({ patern_name: 1 }, { unique: true })

  embeds_many :patterns

  accepts_nested_attributes_for :patterns, allow_destroy: true

  rails_admin do
    edit do
      field :patern_name
      field :patterns
    end
  end
end

class Pattern
  include Mongoid::Document

  field :token,   type: String

  embedded_in :pattern_config

  rails_admin do
    edit do
      field :hour, :integer
    end
  end
end

```