### PR TITLE
Support Mongoid's "Custom Primary & Foreign Keys" behavior.

### DIFF
--- a/lib/rails_admin/adapters/mongoid/association.rb
+++ b/lib/rails_admin/adapters/mongoid/association.rb
@@ -41,7 +41,7 @@ module RailsAdmin
         end
 
         def primary_key
-          :_id
+          (options[:primary_key] || :_id).try(:to_sym) unless polymorphic?
         end
 
         def foreign_key
@@ -114,6 +114,7 @@ module RailsAdmin
           association.respond_to?(:cyclic?) ? association.cyclic? : association.cyclic
         end
 
+        delegate :options, :scope, to: :association, prefix: false
         delegate :nested_attributes_options, to: :model, prefix: false
         delegate :polymorphic_parents, to: RailsAdmin::AbstractModel
       end

--- a/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
@@ -7,6 +7,9 @@ module RailsAdmin
         class HasAndBelongsToManyAssociation < RailsAdmin::Config::Fields::Types::HasManyAssociation
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
+          def method_name
+            nested_form ? "#{name}_attributes".to_sym : foreign_key
+          end
         end
       end
     end


### PR DESCRIPTION
In the latest (7.0.2) mongoid document [Mongoid|Associations](https://docs.mongodb.com/mongoid/master/tutorials/mongoid-relations/), primary and foreign keys
can be customized for an association. As a result, we can't assume an association's foreign key is "<name>_id(s)" and primary key is "_id".

With primary & foreign keys customization, below modes:

<pre>
  class Company
    include Mongoid::Document
    # This definition of e_refs is automatically generated by Mongoid:
    # But the type can also be specified:
    field :e_refs, type: Array
    has_and_belongs_to_many :emails, foreign_key: 'e_refs', primary_key: 'e'
  end

  class Email
    include Mongoid::Document
    field :e, type: Object

	rails_admin do
	  object_label_method do
	    :e
	  end
	end
  end
</pre>

will have the documents stored as follows:

<pre>
  # The company document.
  {
    "_id" : ObjectId("4d3ed089fb60ab534684b7e9"),
    "e_refs": ["a@example.com", "b@example.com"]
  }

  # The email document.
  {
    "_id" : ObjectId("4d3ed089fb60ab534684b7f1"),
    "e" : "a@example.com"
  },
  {
    "_id" : ObjectId("4d3ed089fb60ab534684b7f2"),
    "e" : "b@example.com"
  }
</pre>