### PR TITLE
Add support hash in RailsAdmin with Hash filed datatype

### DIFF
--- a/lib/rails_admin/adapters/mongoid/property.rb
+++ b/lib/rails_admin/adapters/mongoid/property.rb
@@ -19,7 +19,6 @@ module RailsAdmin
         end
 
         def type
-          Rails.logger.debug "property.type.to_s #{property.type.to_s}"
           case property.type.to_s
           when 'Array', 'Money'
             :serialized

--- a/lib/rails_admin/adapters/mongoid/property.rb
+++ b/lib/rails_admin/adapters/mongoid/property.rb
@@ -19,9 +19,12 @@ module RailsAdmin
         end
 
         def type
+          Rails.logger.debug "property.type.to_s #{property.type.to_s}"
           case property.type.to_s
-          when 'Array', 'Hash', 'Money'
+          when 'Array', 'Money'
             :serialized
+          when 'Hash'
+            :json
           when 'BigDecimal'
             :decimal
           when 'Boolean', 'Mongoid::Boolean'


### PR DESCRIPTION
Hello, I need to use Hash with RailsAdmin and seems like can't edit hash filed and save it.
Its simple edit as plain Json
#2554 
[old stack overflow question](https://stackoverflow.com/questions/16783336/mongoid-admin-with-hash-and-array-field-types)
Here is how its look like:
<img width="191" alt="screenshot 2019-01-17 at 14 00 47" src="https://user-images.githubusercontent.com/8098344/51314170-5a8ec780-1a60-11e9-974d-eb7a8c7866ef.png">
<img width="232" alt="screenshot 2019-01-17 at 14 00 54" src="https://user-images.githubusercontent.com/8098344/51314171-5a8ec780-1a60-11e9-8b09-2d4738510212.png">
I have no idea broke it or not but it's work for me.
