### PR TITLE
Fix wrong styles when using multiple instances of CodeMirror

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -240,6 +240,7 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
         options = $(this).data('options')
         textarea = this
         $.getScript options['locations']['mode'], (script, textStatus, jqXHR) ->
+          options = $(domEle).data('options')
           $('head').append('<link href="' + options['locations']['theme'] + '" rel="stylesheet" media="all" type="text\/css">')
           CodeMirror.fromTextArea(textarea,options['options'])
           $(textarea).addClass('codemirrored')


### PR DESCRIPTION
Hi! 

I faced with a problem when I have multiple CodeMirror instances on a single page. The problem is that  the only last style will be applied to all CodeMirror instances.

For example, I have two fields and I wish to write ruby code in the first and javascript in the second:

```ruby
      field :code, :code_mirror do
        config({
                 mode: 'ruby',
                 theme: 'monokai'
               })
        assets({
                 mode: ::ActionController::Base.helpers.asset_path('codemirror/modes/ruby.js'),
                 theme: ::ActionController::Base.helpers.asset_path('codemirror/themes/monokai.css')
               })
      end
      field :callback, :code_mirror do
        config({
                 mode: 'javascript',
                 theme: 'material'
               })
        assets({
                 mode: ::ActionController::Base.helpers.asset_path('codemirror/modes/javascript.js'),
                 theme: ::ActionController::Base.helpers.asset_path('codemirror/themes/material.css')
               })
      end
```

But as a result for both fields were applied javascript mode + material theme.

I guess that it's a typical javascript async error when variable was redefined before success callback was executed. This is why my short fix gets options directly from dom element in the callback.