### PR TITLE
Does not parse empty enum value

### DIFF
--- a/lib/rails_admin/config/fields/types/active_record_enum.rb
+++ b/lib/rails_admin/config/fields/types/active_record_enum.rb
@@ -42,7 +42,8 @@ module RailsAdmin
 
           def parse_input(params)
             value = params[name]
-            return unless value
+            return unless value.present?
+            
             params[name] = parse_input_value(value)
           end
 


### PR DESCRIPTION
Prevent parse empty enum value that cause to automatic fill enum field with blue instead of nil.

```ruby
  enum color: {
    blue: 0,
    red: 1
  }
```