### PR TITLE
Add Bootstrap 4 compatibility

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -3,7 +3,7 @@
   Keep it clean, people
 */
 
-$avatar-size: 30px;
+$avatar-size: px_to_em(30);
 
 body.rails_admin {
 
@@ -20,10 +20,10 @@ body.rails_admin {
 
       img {
         position: absolute;
-        top: ((40px - $avatar-size) / 2);
+        top: ((px_to_em(40) - $avatar-size) / 2);
 
         & + span {
-          margin-left: ($avatar-size + 5px);
+          margin-left: ($avatar-size + px_to_em(5));
         }
       }
     }

--- a/app/assets/stylesheets/rails_admin/bootstrap/_navbar.scss
+++ b/app/assets/stylesheets/rails_admin/bootstrap/_navbar.scss
@@ -192,7 +192,7 @@
   float: right;
   margin-right: $navbar-padding-horizontal;
   padding: 9px 10px;
-  @include navbar-vertical-align(34px);
+  @include navbar-vertical-align(px_to_em(34));
   background-color: transparent;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;

--- a/app/assets/stylesheets/rails_admin/bootstrap/_variables.scss
+++ b/app/assets/stylesheets/rails_admin/bootstrap/_variables.scss
@@ -49,7 +49,7 @@ $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 $font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace !default;
 $font-family-base:        $font-family-sans-serif !default;
 
-$font-size-base:          14px !default;
+$font-size-base:          px_to_em(14) !default;
 $font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
 $font-size-small:         ceil(($font-size-base * 0.85)) !default; // ~12px
 
@@ -88,17 +88,17 @@ $icon-font-svg-id:        "glyphicons_halflingsregular" !default;
 //
 //## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
 
-$padding-base-vertical:     6px !default;
-$padding-base-horizontal:   12px !default;
+$padding-base-vertical:     px_to_em(6) !default;
+$padding-base-horizontal:   px_to_em(12) !default;
 
-$padding-large-vertical:    10px !default;
-$padding-large-horizontal:  16px !default;
+$padding-large-vertical:    px_to_em(10) !default;
+$padding-large-horizontal:  px_to_em(16) !default;
 
-$padding-small-vertical:    5px !default;
-$padding-small-horizontal:  10px !default;
+$padding-small-vertical:    px_to_em(5) !default;
+$padding-small-horizontal:  px_to_em(10) !default;
 
-$padding-xs-vertical:       1px !default;
-$padding-xs-horizontal:     5px !default;
+$padding-xs-vertical:       px_to_em(1) !default;
+$padding-xs-horizontal:     px_to_em(5) !default;
 
 $line-height-large:         1.33 !default;
 $line-height-small:         1.5 !default;
@@ -339,7 +339,7 @@ $container-lg:                 $container-large-desktop !default;
 //##
 
 // Basics of a navbar
-$navbar-height:                    50px !default;
+$navbar-height:                    px_to_em(50) !default;
 $navbar-margin-bottom:             $line-height-computed !default;
 $navbar-border-radius:             $border-radius-base !default;
 $navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;

--- a/app/assets/stylesheets/rails_admin/custom/functions.scss
+++ b/app/assets/stylesheets/rails_admin/custom/functions.scss
@@ -1,0 +1,6 @@
+
+$browser-context: 16; // Default
+
+@function px_to_em($pixels, $context: $browser-context) {
+  @return ($pixels/$context) * 1rem;
+}

--- a/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
+++ b/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
@@ -35,6 +35,7 @@
 
 /***  Variables  ***/
 
+@import "rails_admin/custom/functions";
 @import "rails_admin/custom/variables";
 @import "rails_admin/bootstrap/variables";
 @import "rails_admin/base/variables";
@@ -104,6 +105,3 @@
 @import "rails_admin/base/theming";
 @import "rails_admin/themes/<%= theme %>/theming";
 @import "rails_admin/custom/theming";
-
-
-


### PR DESCRIPTION
Added function to convert px units to em (divide by 16). Modified any styles that fail to precompile with Bootstrap 4 due to mixing px and em units - These now call the px_to_em function to convert the px units to em.

Note: I have not converted every px unit to em, only those that caused a rake assets:precompile failure. Also note there are no specs for this change - I kept running rake assets:precompile until it succeeded, changing one px unit at a time.