### PR TITLE
Fix localization of "time ago in words"

### DIFF
--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -18,8 +18,7 @@
               %span.show= link_to capitalize_first_letter(abstract_model.config.label_plural), index_path, class: 'pjax'
             %td
               - if last_created
-                = time_ago_in_words last_created
-                = t "admin.misc.ago"
+                = t "admin.misc.time_ago", time: time_ago_in_words(last_created)
             %td
               - count = @count[abstract_model.model.name]
               - percent = count > 0 ? (@max <= 1 ? count : ((Math.log(count+1) * 100.0) / Math.log(@max+1)).to_i) : -1

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -43,7 +43,7 @@ en:
       navigation: "Navigation"
       navigation_static_label: "Links"
       log_out: "Log out"
-      ago: "ago"
+      time_ago: "%{time} ago"
       more: "Plus %{count} more %{models_name}"
     flash:
       successful: "%{name} successfully %{action}"


### PR DESCRIPTION
Not all languages have the same order as English ("x months ago" <-> "il y a x mois")