### PR TITLE
CI: Use jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,10 @@ matrix:
     - rvm: ruby-head
       env: CI_ORM=active_record CI_DB_ADAPTER=sqlite3
       gemfile: gemfiles/rails_5.2.gemfile
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env: CI_ORM=mongoid
       gemfile: gemfiles/rails_5.2.gemfile
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env: CI_ORM=active_record CI_DB_ADAPTER=sqlite3
       gemfile: gemfiles/rails_5.2.gemfile
     - rvm: jruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html) of April 09 2019.

