### PR TITLE
Add rel='noopener noreferrer' to links with target=_blank

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -101,7 +101,7 @@ module RailsAdmin
 
     def static_navigation
       li_stack = RailsAdmin::Config.navigation_static_links.collect do |title, url|
-        content_tag(:li, link_to(title.to_s, url, target: '_blank'))
+        content_tag(:li, link_to(title.to_s, url, target: '_blank', rel: 'noopener noreferrer'))
       end.join
 
       label = RailsAdmin::Config.navigation_static_label || t('admin.misc.navigation_static_label')

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -38,9 +38,9 @@ module RailsAdmin
               if image
                 thumb_url = resource_url(thumb_method)
                 image_html = v.image_tag(thumb_url, class: 'img-thumbnail')
-                url != thumb_url ? v.link_to(image_html, url, target: '_blank') : image_html
+                url != thumb_url ? v.link_to(image_html, url, target: '_blank', rel: 'noopener noreferrer') : image_html
               else
-                v.link_to(value, url, target: '_blank')
+                v.link_to(value, url, target: '_blank', rel: 'noopener noreferrer')
               end
             end
           end

--- a/lib/rails_admin/config/fields/types/multiple_file_upload.rb
+++ b/lib/rails_admin/config/fields/types/multiple_file_upload.rb
@@ -34,9 +34,9 @@ module RailsAdmin
                 if image
                   thumb_url = resource_url(thumb_method)
                   image_html = v.image_tag(thumb_url, class: 'img-thumbnail')
-                  url != thumb_url ? v.link_to(image_html, url, target: '_blank') : image_html
+                  url != thumb_url ? v.link_to(image_html, url, target: '_blank', rel: 'noopener noreferrer') : image_html
                 else
-                  v.link_to(value, url, target: '_blank')
+                  v.link_to(value, url, target: '_blank', rel: 'noopener noreferrer')
                 end
               end
             end


### PR DESCRIPTION
This PR adds security-related HTML properties to links with the `target=_blank` attribute.

See #2960 for more details.

<details>

  - Cater to old Firefox, before 52, with rel=noreferrer as well
    https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52#HTML


</details>