### PR TITLE
Rails 6 gemfile: Use devise 4.7.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -95,7 +95,7 @@ appraise "rails-6.0" do
   gem 'rails', '~> 6.0.0'
   gem 'haml'
   gem 'sassc-rails', '~> 2.1'
-  gem 'devise', '~> 4.4', github: 'plataformatec/devise'
+  gem 'devise', '~> 4.7'
 
   group :test do
     gem 'cancancan', '~> 3.0'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", ">= 2.0"
 gem "rails", "~> 6.0.0"
 gem "haml"
-gem "devise", "~> 4.4", github: "plataformatec/devise"
+gem "devise", "~> 4.7"
 gem "sassc-rails", "~> 2.1"
 
 group :active_record do


### PR DESCRIPTION
This PR updates the gemfile for Rails 6: [devise 4.7.0 is out](https://github.com/plataformatec/devise/releases/tag/v4.7.0), supporting Rails 6.