### PR TITLE
Bump haml version requirement in gemspec

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -6,7 +6,7 @@ require 'rails_admin/version'
 Gem::Specification.new do |spec|
   # If you add a dependency, please maintain alphabetical order
   spec.add_dependency 'builder', '~> 3.1'
-  spec.add_dependency 'haml', '>= 4.0', '< 6'
+  spec.add_dependency 'haml', '~> 5.1.1'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'jquery-ui-rails', ['>= 5.0', '< 7']
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'


### PR DESCRIPTION
haml versions below 5.1.1 will crash with rails 6.0.0 due to a missing Erubi constant. 

See: https://github.com/haml/haml/issues/1011

background: rails_admin crashed for me because i had an old (but still accepted according to gemspec) haml version laying around when installing.
