### PR TITLE
Update rubocop to 0.68.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,15 @@ AllCops:
     - 'spec/dummy_app/tmp/**/*'
     - 'vendor/bundle/**/*'
 
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Metrics/AbcSize:
   Max: 69.98 # TODO: Lower to 15
 
@@ -38,8 +47,9 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 14 # TODO: Lower to 7
 
-Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
+Naming/FileName:
+  Exclude:
+    - 'lib/rails_admin/bootstrap-sass.rb'
 
 Style/Alias:
   Enabled: false
@@ -54,9 +64,6 @@ Style/CollectionMethods:
 Style/Documentation:
   Enabled: false
 
-Style/DotPosition:
-  EnforcedStyle: trailing
-
 Style/DoubleNegation:
   Enabled: false
 
@@ -65,10 +72,6 @@ Style/EachWithObject:
 
 Style/Encoding:
   Enabled: false
-
-Style/FileName:
-  Exclude:
-    - 'lib/rails_admin/bootstrap-sass.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: false
@@ -79,11 +82,11 @@ Style/Lambda:
 Style/RaiseArgs:
   EnforcedStyle: compact
 
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,25 +5,153 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+Bundler/OrderedGems:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/LeadingBlankLines:
+  Enabled: false
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 # Offense count: 22
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:
   Enabled: false
 
+Lint/DuplicateMethods:
+  Enabled: false
+
+Lint/ReturnInVoidContext:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Enabled: false
+
+Lint/UnneededSplatExpansion:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+  Max: 51
+
 # Offense count: 7
 Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+Naming/VariableNumber:
   Enabled: false
 
 # Offense count: 11
 Style/ClassVars:
   Enabled: false
 
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/EvalWithLocation:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false
+
+Style/MethodMissingSuper:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false
+
+Style/MissingRespondToMissing:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/OrAssignment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RedundantSelf:
+  Enabled: false
+
 # Offense count: 7
 Style/RescueModifier:
+  Enabled: false
+
+Style/RescueStandardError:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/StderrPuts:
   Enabled: false
 
 Style/StringLiterals:
   Enabled: false
 
+Style/SymbolArray:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
 Style/WordArray:
+  Enabled: false
+
+Style/YodaCondition:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,7 +11,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 # Offense count: 7
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 # Offense count: 11
@@ -21,10 +21,6 @@ Style/ClassVars:
 # Offense count: 7
 Style/RescueModifier:
   Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
 
 Style/StringLiterals:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'rspec-rails', '>= 2.14'
   gem 'rspec-expectations', '!= 3.8.3'
   gem 'rubocop', '~> 0.68.1'
+  gem 'rubocop-performance'
   gem 'simplecov', '>= 0.9', require: false
   gem 'shrine', '~> 2.0'
   gem 'shrine-memory'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :test do
   gem 'rack-cache', require: 'rack/cache'
   gem 'rspec-rails', '>= 2.14'
   gem 'rspec-expectations', '!= 3.8.3'
-  gem 'rubocop', '~> 0.41.2'
+  gem 'rubocop', '~> 0.68.1'
   gem 'simplecov', '>= 0.9', require: false
   gem 'shrine', '~> 2.0'
   gem 'shrine-memory'

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -125,7 +125,7 @@ module RailsAdmin
     def breadcrumb(action = @action, _acc = [])
       begin
         (parent_actions ||= []) << action
-      end while action.breadcrumb_parent && (action = action(*action.breadcrumb_parent)) # rubocop:disable Loop
+      end while action.breadcrumb_parent && (action = action(*action.breadcrumb_parent)) # rubocop:disable Lint/Loop
 
       content_tag(:ol, class: 'breadcrumb') do
         parent_actions.collect do |a|

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -43,6 +43,7 @@ group :test do
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
   gem "rubocop", "~> 0.68.1"
+  gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -42,7 +42,7 @@ group :test do
   gem "rack-cache", require: "rack/cache"
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
-  gem "rubocop", "~> 0.41.2"
+  gem "rubocop", "~> 0.68.1"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -43,7 +43,7 @@ group :test do
   gem "rack-cache", require: "rack/cache"
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
-  gem "rubocop", "~> 0.41.2"
+  gem "rubocop", "~> 0.68.1"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -44,6 +44,7 @@ group :test do
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
   gem "rubocop", "~> 0.68.1"
+  gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -43,7 +43,7 @@ group :test do
   gem "rack-cache", require: "rack/cache"
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
-  gem "rubocop", "~> 0.41.2"
+  gem "rubocop", "~> 0.68.1"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -44,6 +44,7 @@ group :test do
   gem "rspec-rails", ">= 2.14"
   gem "rspec-expectations", "!= 3.8.3"
   gem "rubocop", "~> 0.68.1"
+  gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -38,6 +38,7 @@ group :test do
   gem "rspec-rails", ">= 4.0.0.beta2"
   gem "rspec-expectations", "!= 3.8.3"
   gem "rubocop", "~> 0.68.1"
+  gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -37,7 +37,7 @@ group :test do
   gem "rack-cache", require: "rack/cache"
   gem "rspec-rails", ">= 4.0.0.beta2"
   gem "rspec-expectations", "!= 3.8.3"
-  gem "rubocop", "~> 0.41.2"
+  gem "rubocop", "~> 0.68.1"
   gem "simplecov", ">= 0.9", require: false
   gem "shrine", "~> 2.0"
   gem "shrine-memory"

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -346,7 +346,7 @@ module RailsAdmin
                   end
                 end
               end
-            end.flatten.reject { |m| m.starts_with?('Concerns::') } # rubocop:disable MultilineBlockChain
+            end.flatten.reject { |m| m.starts_with?('Concerns::') } # rubocop:disable Style/MultilineBlockChain
         end
       end
 

--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -7,7 +7,7 @@ module RailsAdmin
         base.send :extend, ClassMethods
       end
 
-      def has_option?(name) # rubocop:disable PredicateName
+      def has_option?(name) # rubocop:disable Naming/PredicateName
         options = self.class.instance_variable_get('@config_options')
         options && options.key?(name)
       end

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -7,7 +7,7 @@ require 'rails_admin/config/inspectable'
 module RailsAdmin
   module Config
     module Fields
-      class Base # rubocop:disable ClassLength
+      class Base # rubocop:disable Metrics/ClassLength
         include RailsAdmin::Config::Proxyable
         include RailsAdmin::Config::Configurable
         include RailsAdmin::Config::Hideable

--- a/lib/rails_admin/config/has_groups.rb
+++ b/lib/rails_admin/config/has_groups.rb
@@ -16,7 +16,7 @@ module RailsAdmin
 
       # Reader for groups that are marked as visible
       def visible_groups
-        parent.groups.collect { |f| f.section = self; f.with(bindings) }.select(&:visible?).select do |g| # rubocop:disable Semicolon
+        parent.groups.collect { |f| f.section = self; f.with(bindings) }.select(&:visible?).select do |g| # rubocop:disable Style/Semicolon
           g.visible_fields.present?
         end
       end

--- a/lib/rails_admin/extension.rb
+++ b/lib/rails_admin/extension.rb
@@ -1,9 +1,9 @@
 
 module RailsAdmin
-  EXTENSIONS = [] # rubocop:disable MutableConstant
-  AUTHORIZATION_ADAPTERS = {} # rubocop:disable MutableConstant
-  AUDITING_ADAPTERS = {} # rubocop:disable MutableConstant
-  CONFIGURATION_ADAPTERS = {} # rubocop:disable MutableConstant
+  EXTENSIONS = [] # rubocop:disable Style/MutableConstant
+  AUTHORIZATION_ADAPTERS = {} # rubocop:disable Style/MutableConstant
+  AUDITING_ADAPTERS = {} # rubocop:disable Style/MutableConstant
+  CONFIGURATION_ADAPTERS = {} # rubocop:disable Style/MutableConstant
 
   # Extend RailsAdmin
   #

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -7,7 +7,7 @@ require 'sprockets/railtie'
 begin
   require CI_ORM.to_s
   require "#{CI_ORM}/railtie"
-rescue LoadError # rubocop:disable HandleExceptions
+rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 require 'active_storage/engine' if Rails.version >= '5.2.0' && CI_ORM == :active_record

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RailsAdmin::Config do
   describe '.add_extension' do
     before do
       silence_warnings do
-        RailsAdmin::EXTENSIONS = [] # rubocop:disable MutableConstant
+        RailsAdmin::EXTENSIONS = [] # rubocop:disable Style/MutableConstant
       end
     end
 


### PR DESCRIPTION
Fixes #3197 

The latest version of rubocop is version 0.75.0, but version 0.70.0 or above requires ruby 2.3.0 or above. Therefore, this PR is updating rubocop version 0.68.1 that supports ruby 2.2.2.

I put all new cops into `.rubocop_todo.yml` and disable them for now.
