### PR TITLE
Fix the case where username is nil, not whodunnit

### DIFF
--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -23,7 +23,7 @@ module RailsAdmin
         end
 
         def username
-          @user_class.find(@version.whodunnit).try(:email) rescue nil || @version.whodunnit
+          (@user_class.find(@version.whodunnit).try(:email) rescue nil) || @version.whodunnit
         end
 
         def item

--- a/spec/extentions/paper_trail/auditing_adapter_spec.rb
+++ b/spec/extentions/paper_trail/auditing_adapter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RailsAdmin::Extensions::PaperTrail::VersionProxy do
+  describe '#username' do
+    subject { described_class.new(version, user_class).username }
+
+    let(:version) { double(whodunnit: :the_user) }
+    let(:user_class) { double(find: user) }
+
+    context 'when found user has email' do
+      let(:user) { double(email: :mail) }
+      it { is_expected.to eq(:mail) }
+    end
+
+    context 'when found user does not have email' do
+      let(:user) { double } # no email method
+
+      it { is_expected.to eq(:the_user) }
+    end
+  end
+end


### PR DESCRIPTION
I encounter the problem where paper_trails's whodunnit isn't displayed.
It turned out that `username` method returns nil.
`try` method returns nil when there's no method, so when user doesn't have `email` method,
`@user_class.find(@version.whodunnit).try(:email)` returns nil.
Then, try this out:
`nil rescue nil || :foo`
This returns nil, surprisingly.
This means if user doesn't have email method, username is always nil.
So my fix is like below:
`(nil rescue nil) || :foo`
This returns `:foo` as expected.