### PR TITLE
Only hide empty values if compact mode is enabled

### DIFF
--- a/app/views/rails_admin/main/show.html.haml
+++ b/app/views/rails_admin/main/show.html.haml
@@ -1,6 +1,6 @@
 - @model_config.show.with(object: @object, view: self, controller: self.controller).visible_groups.each do |fieldset|
   - unless (fields = fieldset.with(object: @object, view: self, controller: self.controller).visible_fields).empty?
-    - unless (fields = fields.reject{ |f| RailsAdmin::config.compact_show_view && f.formatted_value.nil? || f.formatted_value == '' }).empty?
+    - unless (fields = fields.reject{ |f| RailsAdmin::config.compact_show_view && (f.formatted_value.nil? || f.formatted_value == '') }).empty?
       .fieldset
         %h4
           = fieldset.label

--- a/spec/integration/actions/show_spec.rb
+++ b/spec/integration/actions/show_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe 'Show action', type: :request do
     end
   end
 
+  context 'when compact_show_view is disabled' do
+    before do
+      RailsAdmin.config do |c|
+        c.compact_show_view = false
+      end
+    end
+
+    it 'shows nil fields' do
+      team.update logo_url: nil
+      visit show_path(model_name: 'team', id: team.id)
+      is_expected.to have_css('.logo_url_field')
+    end
+
+    it 'shows blank fields' do
+      team.update logo_url: ''
+      visit show_path(model_name: 'team', id: team.id)
+      is_expected.to have_css('.logo_url_field')
+    end
+  end
+
   describe 'bindings' do
     it 'should be present' do
       RailsAdmin.config Team do |_c|


### PR DESCRIPTION
If a value is an empty string, it currently is hidden regardless of the setting `compact_show_view`. 

I think an empty string should only be hidden if compact mode is enabled. This PR enables that behaviour.