### PR TITLE
Avoid mutable constant warning in a test

### DIFF
--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RailsAdmin::Config do
   describe '.add_extension' do
     before do
       silence_warnings do
-        RailsAdmin::EXTENSIONS = [] # rubocop:disable Style/MutableConstant
+        RailsAdmin.const_set('EXTENSIONS', [])
       end
     end
 


### PR DESCRIPTION
This PR avoids an explicitly added exemption from a RuboCop warning.