### PR TITLE
Use kaminary param_name for pagination

### DIFF
--- a/lib/rails_admin/config/actions/history_index.rb
+++ b/lib/rails_admin/config/actions/history_index.rb
@@ -19,7 +19,7 @@ module RailsAdmin
         register_instance_option :controller do
           proc do
             @general = true
-            @history = @auditing_adapter && @auditing_adapter.listing_for_model(@abstract_model, params[:query], params[:sort], params[:sort_reverse], params[:all], params[:page]) || []
+            @history = @auditing_adapter && @auditing_adapter.listing_for_model(@abstract_model, params[:query], params[:sort], params[:sort_reverse], params[:all], params[Kaminari.config.param_name]) || []
 
             render @action.template_name
           end


### PR DESCRIPTION
Kaminary has a configuration to custom `param_name`, and this change use that configuration like does [Main index](https://github.com/sferik/rails_admin/blob/9abc1be0c1fee006a7a746583461891911fe9330/app/controllers/rails_admin/main_controller.rb#L125) instead of use hard code `:page` name