### PR TITLE
Fix obsolete setting of Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,7 +52,7 @@ Lint/ReturnInVoidContext:
 Lint/ScriptPermission:
   Enabled: false
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: false
 
 Metrics/BlockLength:

--- a/spec/rails_admin/adapters/active_record/association_spec.rb
+++ b/spec/rails_admin/adapters/active_record/association_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord::Association', active_record:
   end
 
   it 'lists associations' do
-    expect(@post.associations.collect { |a| a.name.to_s }).to include(*%w(a_r_blog a_r_categories a_r_comments))
+    expect(@post.associations.collect { |a| a.name.to_s }).to include('a_r_blog', 'a_r_categories', 'a_r_comments')
   end
 
   it 'list associations types in supported [:belongs_to, :has_and_belongs_to_many, :has_many, :has_one]' do
     # ActiveRecord 4.1 converts has_and_belongs_to_many association to has_many
-    expect((@post.associations + @blog.associations + @user.associations).collect(&:type).uniq.collect(&:to_s)).to include(*%w(belongs_to has_many has_one))
+    expect((@post.associations + @blog.associations + @user.associations).collect(&:type).uniq.collect(&:to_s)).to include('belongs_to', 'has_many', 'has_one')
   end
 
   describe 'belongs_to association' do


### PR DESCRIPTION
When I executed linter by Rubocop, an error message below is shown.

```
Error: The `Lint/UnneededSplatExpansion` cop has been renamed to `Lint/RedundantSplatExpansion`. (obsolete configuration found in .rubocop_todo.yml, please update it)
```

So I fixed `.rubocop_todo.yml` and Rubocop violation of `Lint/RedundantSplatExpansion` in `spec/rails_admin/adapters/active_record/association_spec.rb`.