### PR TITLE
Unify variable of #method_missing and #respond_to?

### DIFF
--- a/lib/rails_admin/adapters/active_record/abstract_object.rb
+++ b/lib/rails_admin/adapters/active_record/abstract_object.rb
@@ -23,8 +23,8 @@ module RailsAdmin
           object.save(options)
         end
 
-        def method_missing(name, *args, &block)
-          object.send(name, *args, &block)
+        def method_missing(method_name, *args, &block)
+          object.send(method_name, *args, &block)
         end
       end
     end

--- a/lib/rails_admin/config/lazy_model.rb
+++ b/lib/rails_admin/config/lazy_model.rb
@@ -56,12 +56,12 @@ module RailsAdmin
         @model
       end
 
-      def method_missing(method, *args, &block)
-        target.send(method, *args, &block)
+      def method_missing(method_name, *args, &block)
+        target.send(method_name, *args, &block)
       end
 
-      def respond_to?(method, include_private = false)
-        super || target.respond_to?(method, include_private)
+      def respond_to?(method_name, include_private = false)
+        super || target.respond_to?(method_name, include_private)
       end
     end
   end

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -100,8 +100,8 @@ module RailsAdmin
 
       # Act as a proxy for the base section configuration that actually
       # store the configurations.
-      def method_missing(m, *args, &block)
-        send(:base).send(m, *args, &block)
+      def method_missing(method_name, *args, &block)
+        send(:base).send(method_name, *args, &block)
       end
     end
   end

--- a/lib/rails_admin/config/proxyable/proxy.rb
+++ b/lib/rails_admin/config/proxyable/proxy.rb
@@ -17,18 +17,18 @@ module RailsAdmin
           self
         end
 
-        def method_missing(name, *args, &block)
-          if @object.respond_to?(name)
+        def method_missing(method_name, *args, &block)
+          if @object.respond_to?(method_name)
             reset = @object.bindings
             begin
               @object.bindings = @bindings
-              response = @object.__send__(name, *args, &block)
+              response = @object.__send__(method_name, *args, &block)
             ensure
               @object.bindings = reset
             end
             response
           else
-            super(name, *args, &block)
+            super(method_name, *args, &block)
           end
         end
       end


### PR DESCRIPTION
Unify first variable of `#method_missing`  and `#respond_to?` to `method_name`.