### PR TITLE
Case-insensitive date parsing when delocalising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/sferik/rails_admin/compare/v2.0.1...HEAD)
 
+### Fixed
+- Improved I18n date format handling ([#3238](https://github.com/sferik/rails_admin/pull/3238))
+
 
 ## [2.0.1](https://github.com/sferik/rails_admin/tree/v2.0.1) - 2019-12-31
 

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -43,7 +43,7 @@ module RailsAdmin
               month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/i, english[i]) }
             when '%b'
               english = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
-              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/i, english[i]) }
+              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{Regexp.escape(m)}/i, english[i]) }
             when '%p'
               date_string = date_string.gsub(/\b#{::I18n.t('date.time.am', default: "am")}\b/i, 'am')
               date_string = date_string.gsub(/\b#{::I18n.t('date.time.pm', default: "pm")}\b/i, 'pm')

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -34,19 +34,19 @@ module RailsAdmin
             case match
             when '%A'
               english = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-              day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+              day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/i, english[i]) }
             when '%a'
               english = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-              abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+              abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/i, english[i]) }
             when '%B'
-              english = [nil, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][1..-1]
-              month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              english = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+              month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/i, english[i]) }
             when '%b'
-              english = [nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][1..-1]
-              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              english = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/i, english[i]) }
             when '%p'
-              date_string = date_string.gsub(/#{::I18n.t('date.time.am', default: "am")}/, 'am')
-              date_string = date_string.gsub(/#{::I18n.t('date.time.pm', default: "pm")}/, 'pm')
+              date_string = date_string.gsub(/\b#{::I18n.t('date.time.am', default: "am")}\b/i, 'am')
+              date_string = date_string.gsub(/\b#{::I18n.t('date.time.pm', default: "pm")}\b/i, 'pm')
             end
           end
           date_string

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -16,4 +16,36 @@ RSpec.describe RailsAdmin::Support::Datetime do
       end
     end
   end
+
+  describe '.delocalize' do
+    around do |example|
+      original_locale = I18n.locale
+      I18n.locale = test_locale
+      example.run
+      I18n.locale = original_locale
+    end
+    let(:format) { '%a %A %d %b %B %I:%M%p' }
+    let(:english_translation) { 'Thu Thursday 02 Jan January 05:30pm' }
+
+    context 'when en locale' do
+      let(:test_locale) { :en }
+      let(:input) { english_translation }
+
+      it 'returns the original string' do
+        result = RailsAdmin::Support::Datetime.delocalize(input, format)
+        expect(result).to eq(input)
+      end
+    end
+
+    context 'when non-en locale' do
+      let(:test_locale) { :fr }
+      # Note: By default, rails-i18n uses all lower-case for Spanish day/month names
+      let(:input) { 'Jeu Jeudi 02 Jan Janvier 05:30pm' }
+
+      it 'returns the English translated string' do
+        result = RailsAdmin::Support::Datetime.delocalize(input, format)
+        expect(result).to eq(english_translation)
+      end
+    end
+  end
 end

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe RailsAdmin::Support::Datetime do
 
   describe '.delocalize' do
     around do |example|
-      original_locale = I18n.locale
-      I18n.locale = test_locale
-      example.run
-      I18n.locale = original_locale
+      I18n.with_locale(test_locale) { example.run }
     end
     let(:format) { '%a %A %d %b %B %I:%M%p' }
     let(:english_translation) { 'Thu Thursday 02 Jan January 05:30pm' }
@@ -39,7 +36,7 @@ RSpec.describe RailsAdmin::Support::Datetime do
 
     context 'when non-en locale' do
       let(:test_locale) { :fr }
-      # Note: By default, rails-i18n uses all lower-case for Spanish day/month names
+      # Note: Translation uses all lower-case day/month names
       let(:input) { 'Jeu Jeudi 02 Jan. Janvier 05:30pm' }
 
       it 'returns the English translated string' do

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RailsAdmin::Support::Datetime do
     context 'when non-en locale' do
       let(:test_locale) { :fr }
       # Note: By default, rails-i18n uses all lower-case for Spanish day/month names
-      let(:input) { 'Jeu Jeudi 02 Jan Janvier 05:30pm' }
+      let(:input) { 'Jeu Jeudi 02 Jan. Janvier 05:30pm' }
 
       it 'returns the English translated string' do
         result = RailsAdmin::Support::Datetime.delocalize(input, format)


### PR DESCRIPTION
The recent `v2.0.1` release of `rails_admin` included [updating the `momentjs` library](https://github.com/sferik/rails_admin/pull/3201).

A non-obvious side-affect of this is that the newest version of `momentjs` localises dates differently - for example, Spanish days and months are now (correctly?) [formatted as lower-case](https://github.com/moment/moment/blob/develop/locale/es.js) instead of upper-case.

(E.g. Rails admin `2.0.0` formatted today as "2 de Enero de 2020", but version `2.0.1` formats today as "2 de enero de 2020"). (But I'm using `fr` locale in this spec for [convenience](https://github.com/sferik/rails_admin/tree/master/spec/dummy_app/config/locales), since the tests already define it.)

However, `rails-admin` assumed an _exact match_ between the ruby-translations and javascript-translations. Any project which formats those dates differently (i.e. by capitalising them) no longer works with rails-admin.

Ideally, I feel the "right" solution here would be to **not send the date as a human-formatted-string** to the server (!!!) and instead use some well-defined ISO 8601 format; thus eliminating this whole complication.

But for now - as an immediate fix - I propose just making this substitution case insensitive.

---

N.B. The code climate "failure" doesn't actually change the existing code structure.