### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This library aims to support and is [tested against][travis] the following Ruby 
 * Ruby 2.4
 * Ruby 2.5
 * Ruby 2.6
+* Ruby 2.7
 * [JRuby][]
 
 [jruby]: http://jruby.org/


### PR DESCRIPTION
Hi, I noticed that rails_admin supports Ruby 2.7 and this information was not in the readme.

:smile: 

Thanks for this awesome gem! :+1: 