### PR TITLE
Remove not using of yell_for_non_accessible_fields

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -82,9 +82,6 @@ module RailsAdmin
       attr_accessor :navigation_static_links
       attr_accessor :navigation_static_label
 
-      # yell about fields that are not marked as accessible
-      attr_accessor :yell_for_non_accessible_fields
-
       # Setup authentication to be run as a before filter
       # This is run inside the controller instance so you can setup any authentication you need to
       #
@@ -271,7 +268,6 @@ module RailsAdmin
       def reset
         @compact_show_view = true
         @browser_validations = true
-        @yell_for_non_accessible_fields = true
         @authenticate = nil
         @authorize = nil
         @audit = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,7 +79,6 @@ RSpec.configure do |config|
     RailsAdmin::Config.reset
     RailsAdmin::AbstractModel.reset
     RailsAdmin::Config.audit_with(:history) if CI_ORM == :active_record
-    RailsAdmin::Config.yell_for_non_accessible_fields = false
   end
 
   config.after(:each) do


### PR DESCRIPTION
`yell_for_non_accessible_fields` is no longer needed by #1622.
I think this configure is delete.