### PR TITLE
Active storage variants in Rails 6>

### DIFF
--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -8,7 +8,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option :thumb_method do
-            if ::Vips.present?
+            if require('vips')
               {resize_to_limit: [100, 100]}
             else
               {resize: '100x100>'}

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -1,5 +1,4 @@
 require 'rails_admin/config/fields/types/file_upload'
-require 'vips'
 
 module RailsAdmin
   module Config

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -8,7 +8,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option :thumb_method do
-            if require('vips')
+            if Gem.loaded_specs.key?('ruby-vips')
               {resize_to_limit: [100, 100]}
             else
               {resize: '100x100>'}

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -9,7 +9,11 @@ module RailsAdmin
 
           class ActiveStorageAttachment < RailsAdmin::Config::Fields::Types::MultipleFileUpload::AbstractAttachment
             register_instance_option :thumb_method do
-              {resize: '100x100>'}
+              if Gem.loaded_specs.key?('ruby-vips')
+                {resize_to_limit: [100, 100]}
+              else
+                {resize: '100x100>'}
+              end
             end
 
             register_instance_option :delete_value do


### PR DESCRIPTION
Since upgrading to Rails 6, my team changed to use variants in active_storage with vips. In vips the old:

```resize: "100x100"```

results in a broken file for rails_admin users that uses vips.
Instead I've added a check to see if the project is using ruby-vips and in that case they will be using the resize method:

```resize_to_limit: [100, 100]```

Another way to go to check it, is to check:
```config.active_storage.variant_processor ```
if that is preferrable.