### PR TITLE
Upgrading to Shrine 3.x

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -27,7 +27,7 @@ appraise "rails-5.0" do
     gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
     gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
     gem 'cancancan-mongoid'
-    gem 'shrine-mongoid'
+    gem 'shrine-mongoid', '~> 1.0'
   end
 end
 
@@ -57,7 +57,7 @@ appraise "rails-5.1" do
     gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
     gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
     gem 'cancancan-mongoid'
-    gem 'shrine-mongoid'
+    gem 'shrine-mongoid', '~> 1.0'
   end
 end
 
@@ -87,7 +87,7 @@ appraise "rails-5.2" do
     gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
     gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
     gem 'cancancan-mongoid'
-    gem 'shrine-mongoid'
+    gem 'shrine-mongoid', '~> 1.0'
   end
 end
 
@@ -119,6 +119,6 @@ appraise "rails-6.0" do
     gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
     gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
     gem 'cancancan-mongoid', github: 'mshibuya/cancancan-mongoid', branch: 'mongoid-7'
-    gem 'shrine-mongoid'
+    gem 'shrine-mongoid', '~> 1.0'
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -27,7 +27,7 @@ appraise "rails-5.0" do
     gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
     gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
     gem 'cancancan-mongoid'
-    gem 'shrine-mongoid', '~> 1.0'
+    gem 'shrine-mongoid', '~> 0.2'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,7 @@ group :test do
   gem 'rubocop', '~> 0.68.1'
   gem 'rubocop-performance'
   gem 'simplecov', '>= 0.9', require: false
-  gem 'shrine', '~> 2.0'
-  gem 'shrine-memory'
+  gem 'shrine', '~> 3.0'
   gem 'timecop', '>= 0.5'
 
   platforms :ruby_19 do

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -46,8 +46,7 @@ group :test do
   gem "rubocop", "~> 0.68.1"
   gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
-  gem "shrine", "~> 2.0"
-  gem "shrine-memory"
+  gem "shrine", "~> 3.0"
   gem "timecop", ">= 0.5"
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -62,7 +61,7 @@ group :mongoid do
   gem "mongoid-paperclip", ">= 0.0.8", require: "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", require: "carrierwave/mongoid"
   gem "cancancan-mongoid"
-  gem "shrine-mongoid"
+  gem "shrine-mongoid", '~> 1.0'
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -46,7 +46,8 @@ group :test do
   gem "rubocop", "~> 0.68.1"
   gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
-  gem "shrine", "~> 3.0"
+  gem "shrine", "~> 2.13.0"
+  gem "shrine-memory"
   gem "timecop", ">= 0.5"
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -61,7 +62,7 @@ group :mongoid do
   gem "mongoid-paperclip", ">= 0.0.8", require: "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", require: "carrierwave/mongoid"
   gem "cancancan-mongoid"
-  gem "shrine-mongoid", '~> 1.0'
+  gem "shrine-mongoid", "~> 0.2.4"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -47,8 +47,7 @@ group :test do
   gem "rubocop", "~> 0.68.1"
   gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
-  gem "shrine", "~> 2.0"
-  gem "shrine-memory"
+  gem "shrine", "~> 3.0"
   gem "timecop", ">= 0.5"
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -63,7 +62,7 @@ group :mongoid do
   gem "mongoid-paperclip", ">= 0.0.8", require: "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", require: "carrierwave/mongoid"
   gem "cancancan-mongoid"
-  gem "shrine-mongoid"
+  gem "shrine-mongoid", '~> 1.0'
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -47,8 +47,7 @@ group :test do
   gem "rubocop", "~> 0.68.1"
   gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
-  gem "shrine", "~> 2.0"
-  gem "shrine-memory"
+  gem "shrine", "~> 3.0"
   gem "timecop", ">= 0.5"
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -63,7 +62,7 @@ group :mongoid do
   gem "mongoid-paperclip", ">= 0.0.8", require: "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", require: "carrierwave/mongoid"
   gem "cancancan-mongoid"
-  gem "shrine-mongoid"
+  gem "shrine-mongoid", '~> 1.0'
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -47,8 +47,7 @@ group :test do
   gem "rubocop", "~> 0.68.1"
   gem "rubocop-performance"
   gem "simplecov", ">= 0.9", require: false
-  gem "shrine", "~> 2.0"
-  gem "shrine-memory"
+  gem "shrine", "~> 3.0"
   gem "timecop", ">= 0.5"
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -63,7 +62,7 @@ group :mongoid do
   gem "mongoid-paperclip", ">= 0.0.8", require: "mongoid_paperclip"
   gem "carrierwave-mongoid", ">= 0.6.3", require: "carrierwave/mongoid"
   gem "cancancan-mongoid", github: "mshibuya/cancancan-mongoid", branch: "mongoid-7"
-  gem "shrine-mongoid"
+  gem "shrine-mongoid", '~> 1.0'
 end
 
 gemspec path: "../"

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -31,6 +31,10 @@ module RailsAdmin
             resource_url.to_s
           end
 
+          register_instance_option :link_name do
+            value
+          end
+
           register_instance_option :pretty_value do
             if value.presence
               v = bindings[:view]
@@ -40,7 +44,7 @@ module RailsAdmin
                 image_html = v.image_tag(thumb_url, class: 'img-thumbnail')
                 url != thumb_url ? v.link_to(image_html, url, target: '_blank', rel: 'noopener noreferrer') : image_html
               else
-                v.link_to(value, url, target: '_blank', rel: 'noopener noreferrer')
+                v.link_to(link_name, url, target: '_blank', rel: 'noopener noreferrer')
               end
             end
           end

--- a/lib/rails_admin/config/fields/types/shrine.rb
+++ b/lib/rails_admin/config/fields/types/shrine.rb
@@ -10,14 +10,16 @@ module RailsAdmin
           register_instance_option :thumb_method do
             unless defined? @thumb_method
               @thumb_method = begin
-                next nil unless value.is_a?(Hash)
+                next nil unless bindings[:object].respond_to?("#{name}_derivatives")
 
-                if value.key?(:thumb)
+                derivatives = bindings[:object].public_send("#{name}_derivatives")
+
+                if derivatives.key?(:thumb)
                   :thumb
-                elsif value.key?(:thumbnail)
+                elsif derivatives.key?(:thumbnail)
                   :thumbnail
                 else
-                  value.keys.first
+                  derivatives.keys.first
                 end
               end
             end
@@ -32,6 +34,10 @@ module RailsAdmin
             name
           end
 
+          register_instance_option :link_name do
+            value.original_filename
+          end
+
           register_instance_option :cache_value do
             bindings[:object].public_send("cached_#{name}_data") if bindings[:object].respond_to?("cached_#{name}_data")
           end
@@ -39,8 +45,8 @@ module RailsAdmin
           def resource_url(thumb = nil)
             return nil unless value
 
-            if value.is_a?(Hash)
-              value[thumb || value.keys.first].url
+            if thumb
+              bindings[:object].public_send(:"#{name}", thumb).url
             else
               value.url
             end

--- a/lib/rails_admin/config/fields/types/shrine.rb
+++ b/lib/rails_admin/config/fields/types/shrine.rb
@@ -31,15 +31,15 @@ module RailsAdmin
           end
 
           register_instance_option :cache_method do
-            name
+            name if bindings[:object].try("cached_#{name}_data")
+          end
+
+          register_instance_option :cache_value do
+            bindings[:object].try("cached_#{name}_data")
           end
 
           register_instance_option :link_name do
             value.original_filename
-          end
-
-          register_instance_option :cache_value do
-            bindings[:object].public_send("cached_#{name}_data") if bindings[:object].respond_to?("cached_#{name}_data")
           end
 
           def resource_url(thumb = nil)

--- a/lib/rails_admin/config/fields/types/shrine.rb
+++ b/lib/rails_admin/config/fields/types/shrine.rb
@@ -45,11 +45,7 @@ module RailsAdmin
           def resource_url(thumb = nil)
             return nil unless value
 
-            if thumb
-              bindings[:object].public_send(:"#{name}", thumb).url
-            else
-              value.url
-            end
+            thumb && bindings[:object].public_send(:"#{name}", thumb).try(:url) || value.url
           end
         end
       end

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -27,7 +27,7 @@ group :mongoid do
   gem 'kaminari-mongoid'
   gem 'mongoid-paperclip', '>= 0.0.8', require: 'mongoid_paperclip'
   gem 'carrierwave-mongoid', '>= 0.6.3', require: 'carrierwave/mongoid'
-  gem 'shrine-mongoid'
+  gem 'shrine-mongoid', '~> 1.0'
 end
 
 gem 'carrierwave', '>= 2.0.0.rc', '< 3.0'
@@ -37,8 +37,7 @@ gem 'mini_magick', '>= 3.4'
 gem 'mlb', '>= 0.7'
 gem 'paperclip', '>= 3.4'
 gem 'rails_admin', path: '../../'
-gem 'shrine', '~> 2.0'
-gem 'shrine-memory'
+gem 'shrine', '~> 3.0'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
@@ -2,17 +2,14 @@ class ShrineVersioningUploader < Shrine
   plugin :activerecord
 
   plugin :cached_attachment_data
-  plugin :delete_raw
   plugin :determine_mime_type
   plugin :pretty_location
-  plugin :processing
   plugin :remove_attachment
-  plugin :versions
+  plugin :derivatives
 
-  process(:store) do |io|
+  Attacher.derivatives_processor do |original|
     {
-      original: io,
-      thumb: FakeIO.another_version(io, :thumb),
+      thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
     }
   end
 end

--- a/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
@@ -5,11 +5,14 @@ class ShrineVersioningUploader < Shrine
   plugin :determine_mime_type
   plugin :pretty_location
   plugin :remove_attachment
-  plugin :derivatives
 
-  Attacher.derivatives_processor do |original|
-    {
-      thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
-    }
+  if Gem.loaded_specs['shrine'].version >= Gem::Version.create('3')
+    plugin :derivatives
+
+    Attacher.derivatives_processor do |original|
+      {
+        thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
+      }
+    end
   end
 end

--- a/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
@@ -2,17 +2,14 @@ class ShrineVersioningUploader < Shrine
   plugin :mongoid
 
   plugin :cached_attachment_data
-  plugin :delete_raw
   plugin :determine_mime_type
   plugin :pretty_location
-  plugin :processing
   plugin :remove_attachment
-  plugin :versions
+  plugin :derivatives
 
-  process(:store) do |io|
+  Attacher.derivatives_processor do |original|
     {
-      original: io,
-      thumb: FakeIO.another_version(io, :thumb),
+      thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
     }
   end
 end

--- a/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
@@ -5,11 +5,14 @@ class ShrineVersioningUploader < Shrine
   plugin :determine_mime_type
   plugin :pretty_location
   plugin :remove_attachment
-  plugin :derivatives
 
-  Attacher.derivatives_processor do |original|
-    {
-      thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
-    }
+  if Gem.loaded_specs['shrine'].version >= Gem::Version.create('3')
+    plugin :derivatives
+
+    Attacher.derivatives_processor do |original|
+      {
+        thumb: FakeIO.new('', filename: File.basename(original.path), content_type: File.extname(original.path)),
+      }
+    end
   end
 end

--- a/spec/rails_admin/config/fields/types/shrine_spec.rb
+++ b/spec/rails_admin/config/fields/types/shrine_spec.rb
@@ -11,9 +11,13 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Shrine do
     end
 
     before do
-      if record.shrine_versioning_asset
-        record.shrine_versioning_asset_derivatives!
-        record.save
+      if Gem.loaded_specs['shrine'].version >= Gem::Version.create('3')
+        if record.shrine_versioning_asset
+          record.shrine_versioning_asset_derivatives!
+          record.save
+        end
+      else
+        skip
       end
     end
 

--- a/spec/rails_admin/config/fields/types/shrine_spec.rb
+++ b/spec/rails_admin/config/fields/types/shrine_spec.rb
@@ -3,10 +3,18 @@ require 'spec_helper'
 RSpec.describe RailsAdmin::Config::Fields::Types::Shrine do
   context 'when asset is an image with versions' do
     let(:record) { FactoryBot.create :field_test, shrine_versioning_asset: FakeIO.new('dummy', filename: 'test.jpg', content_type: 'image/jpeg') }
+
     let(:field) do
       RailsAdmin.config('FieldTest').fields.detect do |f|
         f.name == :shrine_versioning_asset
       end.with(object: record)
+    end
+
+    before do
+      if record.shrine_versioning_asset
+        record.shrine_versioning_asset_derivatives!
+        record.save
+      end
     end
 
     describe '#image?' do
@@ -18,7 +26,7 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Shrine do
     describe '#value' do
       context 'when attachment exists' do
         it 'returns attached object' do
-          expect(field.value).to be_a(Hash)
+          expect(field.value).to be_a(ShrineVersioningUploader::UploadedFile)
         end
       end
 
@@ -40,7 +48,7 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Shrine do
     describe '#resource_url' do
       context 'when calling without thumb' do
         it 'returns original url' do
-          expect(field.resource_url).to match(/original-/)
+          expect(field.resource_url).to_not match(/thumb-/)
         end
       end
 

--- a/spec/rails_admin/config/fields/types/shrine_spec.rb
+++ b/spec/rails_admin/config/fields/types/shrine_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Shrine do
       end
     end
 
+    describe '#link_name' do
+      it 'returns filename' do
+        expect(field.link_name).to eq('test.jpg')
+      end
+    end
+
     describe '#value' do
       context 'when attachment exists' do
         it 'returns attached object' do

--- a/spec/support/fakeio.rb
+++ b/spec/support/fakeio.rb
@@ -10,14 +10,6 @@ class FakeIO
     @content_type = content_type
   end
 
-  def self.another_version(object, version_name)
-    FakeIO.new(
-      "#{version_name}-#{object.read}",
-      filename: "#{version_name}-#{object.original_filename}",
-      content_type: object.content_type,
-    )
-  end
-
   extend Forwardable
   delegate %i(read rewind eof? close size) => :@io
 end


### PR DESCRIPTION
Considering that `derivatives` plugin replaced `versions` plugin in **shrine 3.x**, some code should be updated.

-------------------------------------------------

Also, I added `link_name` option to `RailsAdmin::Config::Fields::Types::FileUpload`. I hope it's okay. I did it because currently links for shrine fields don't look nice:

![image](https://user-images.githubusercontent.com/7620006/75181655-6d85c800-5747-11ea-8149-6d598b481ff3.png)

