### PR TITLE
CI: Update to JRuby 9.2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,10 @@ matrix:
     - rvm: ruby-head
       env: CI_ORM=active_record CI_DB_ADAPTER=sqlite3
       gemfile: gemfiles/rails_6.0.gemfile
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.11.0
       env: CI_ORM=mongoid
       gemfile: gemfiles/rails_6.0.gemfile
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.11.0
       env: CI_ORM=active_record CI_DB_ADAPTER=sqlite3
       gemfile: gemfiles/rails_6.0.gemfile
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)