### PR TITLE
Fix polymorphic association field with namespaced models

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.js
+++ b/app/assets/javascripts/rails_admin/ra.widgets.js
@@ -202,7 +202,7 @@
         urls = type_select.data('urls');
         type_select.on('change', function(e) {
           var selected_data, selected_type;
-          selected_type = type_select.val().toLowerCase();
+          selected_type = type_select.val().toLowerCase().replace("::", "-");
           selected_data = $("#" + selected_type + "-js-options").data('options');
           object_select.data('options', selected_data);
           object_select.filteringSelect("destroy");

--- a/app/views/rails_admin/main/_form_polymorphic_association.html.haml
+++ b/app/views/rails_admin/main/_form_polymorphic_association.html.haml
@@ -12,7 +12,7 @@
   js_data = type_collection.inject({}) do |options, model|
     model_name = model.second.underscore.downcase
     source_abstract_model = RailsAdmin.config(form.object.class).abstract_model
-    options.merge(model_name.gsub("_", "") => {
+    options.merge(model_name.gsub("_", "").gsub("/", "-") => {
       xhr: true,
       remote_source: index_path(model_name, source_object_id: form.object.id, source_abstract_model: source_abstract_model.to_param, current_action: current_action, compact: true),
       float_left: false


### PR DESCRIPTION
The current code is generating invalid jQuery selectors for models with
a namespace.

For instance a model `Users::Account` will generate a `#users::account-js-options` DOM ID into the polymorphic association field template, causing an invalid jQuery selectors and breaking the related javascript code.