### PR TITLE
Fix for authorization issues with pundit

### DIFF
--- a/app/views/rails_admin/main/_submit_buttons.html.haml
+++ b/app/views/rails_admin/main/_submit_buttons.html.haml
@@ -8,7 +8,7 @@
       - if authorized? :new, @abstract_model
         %button.btn.btn-info{type: "submit", name: "_add_another", :'data-disable-with' => t("admin.form.save_and_add_another")}
           = t("admin.form.save_and_add_another")
-      - if authorized? :edit, @abstract_model
+      - if authorized? :edit, @abstract_model, @object
         %button.btn.btn-info{type: "submit", name: "_add_edit", :'data-disable-with' => t("admin.form.save_and_edit")}
           = t("admin.form.save_and_edit")
       %button.btn.btn-default{type: "submit", name: "_continue", :'data-disable-with' => t("admin.form.cancel"), :formnovalidate => true}

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -53,7 +53,7 @@ module RailsAdmin
         end
 
         register_instance_option :authorization_key do
-          :destroy
+          :bulk_delete
         end
 
         register_instance_option :bulkable? do


### PR DESCRIPTION
- authorized? in _submit_buttons.html.haml called incorrectly:
  "edit" is a member action, therefore "authorized?" has to be called including @object, otherwise an error is thrown upon authorization in policy if @record is used
- Fix authorization_key for bulk_delete, was :destroy which resulted in error upon authorization, collection != member