### PR TITLE
Feature: add confirmation_text for custom actions

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -156,9 +156,25 @@ module RailsAdmin
       actions = actions(parent, abstract_model, object).select { |a| a.http_methods.include?(:get) && a.show_in_menu }
       actions.collect do |action|
         wording = wording_for(:menu, action)
+        li_class = "icon #{action.key}_#{parent}_link #{'active' if current_action?(action)}"
+        a_href = rails_admin.url_for(
+          action: action.action_name,
+          controller: 'rails_admin/main',
+          model_name: abstract_model.try(:to_param),
+          id: object.try(:persisted?) ? object.try(:id) : nil
+        )
+        confirmation_text =
+          if text_or_lambda = action.try(:confirmation_text)
+            if text_or_lambda.respond_to?(:call)
+              text_or_lambda.call(object)
+            else
+              text_or_lambda
+            end
+          end
+
         %(
-          <li title="#{wording if only_icon}" rel="#{'tooltip' if only_icon}" class="icon #{action.key}_#{parent}_link #{'active' if current_action?(action)}">
-            <a class="#{action.pjax? ? 'pjax' : ''}" href="#{rails_admin.url_for(action: action.action_name, controller: 'rails_admin/main', model_name: abstract_model.try(:to_param), id: (object.try(:persisted?) && object.try(:id) || nil))}">
+          <li title="#{wording if only_icon}" rel="#{'tooltip' if only_icon}" class="#{li_class}">
+            <a class="#{action.pjax? ? 'pjax' : ''}" href="#{a_href}"#{" data-confirm='#{confirmation_text}'" if confirmation_text}>
               <i class="#{action.link_icon}"></i>
               <span#{only_icon ? " style='display:none'" : ''}>#{wording}</span>
             </a>

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -161,16 +161,9 @@ module RailsAdmin
           action: action.action_name,
           controller: 'rails_admin/main',
           model_name: abstract_model.try(:to_param),
-          id: object.try(:persisted?) ? object.try(:id) : nil
+          id: object.try(:persisted?) ? object.try(:id) : nil,
         )
-        confirmation_text =
-          if text_or_lambda = action.try(:confirmation_text)
-            if text_or_lambda.respond_to?(:call)
-              text_or_lambda.call(object)
-            else
-              text_or_lambda
-            end
-          end
+        confirmation_text = action.try(:confirmation_text).try(:call, object)
 
         %(
           <li title="#{wording if only_icon}" rel="#{'tooltip' if only_icon}" class="#{li_class}">


### PR DESCRIPTION
This patch adds a tiny feature that we found useful where we work. It's a confirmation dialog for custom actions. For exemple, let's say you are in the user list and you want to resend a welcome email for someone that complained he/she didn't find it in his/her inbox.

![Screenshot 2020-05-28 16 04 44](https://user-images.githubusercontent.com/3451581/83182941-7ea2f400-a0fd-11ea-9df1-803239c15781.png)

Since this action requires a bit of thinking ("Did I click on the right user?" 🤔 ) we decided to add a confirmation dialog for it. All we have to do is add `confirmation_text` to this custom action:

```ruby
class Admin::ResendWelcomeEmail < RailsAdmin::Config::Actions::Base
  register_instance_option :member do
    true
  end

  register_instance_option :link_icon do
    'icon-envelope'
  end

  register_instance_option :confirmation_text do
    proc do |user|
      "Are you sure you want to resend a welcome email to #{user.name} at #{user.email}?"
    end
  end

  ...
end
```

And then the prompt appears like this:

![Screenshot 2020-05-28 16 06 36](https://user-images.githubusercontent.com/3451581/83183050-a09c7680-a0fd-11ea-91b9-4cd4d9112731.png)

The implementation is quite simple since we are just piggybacking on Rails `data-confirm` tags.