### PR TITLE
Add boundaries around date translations matching

### DIFF
--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -145,6 +145,8 @@ module RailsAdmin
         # @see RailsAdmin::AbstractModel.properties
         register_instance_option :label do
           (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name name
+        rescue ActionView::Template::Error
+          (@label ||= {})[::I18n.locale] ||= name
         end
 
         register_instance_option :hint do

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -145,7 +145,7 @@ module RailsAdmin
         # @see RailsAdmin::AbstractModel.properties
         register_instance_option :label do
           (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name name
-        rescue ActionView::Template::Error
+        rescue I18n::InvalidPluralizationData
           (@label ||= {})[::I18n.locale] ||= name
         end
 

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -34,16 +34,16 @@ module RailsAdmin
             case match
             when '%A'
               english = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
-              day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+              day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/, english[i]) }
             when '%a'
               english = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-              abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/#{d}/, english[i]) }
+              abbr_day_names.each_with_index { |d, i| date_string = date_string.gsub(/\b#{d}\b/, english[i]) }
             when '%B'
               english = [nil, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][1..-1]
-              month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/, english[i]) }
             when '%b'
               english = [nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][1..-1]
-              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/#{m}/, english[i]) }
+              abbr_month_names.each_with_index { |m, i| date_string = date_string.gsub(/\b#{m}\b/, english[i]) }
             when '%p'
               date_string = date_string.gsub(/#{::I18n.t('date.time.am', default: "am")}/, 'am')
               date_string = date_string.gsub(/#{::I18n.t('date.time.pm', default: "pm")}/, 'pm')


### PR DESCRIPTION
eg. June in Czech is substring of July (Červen - Červenec), so w/o the boundaries  `Červenec` translated to `Juneec`, which raised exception in TZ processing and resulted in `nil` value.

Sorry, don't have time to write tests.