### PR TITLE
Show Correct Filename For Multiple Attachments

### DIFF
--- a/lib/rails_admin/config/fields/types/multiple_file_upload.rb
+++ b/lib/rails_admin/config/fields/types/multiple_file_upload.rb
@@ -38,7 +38,8 @@ module RailsAdmin
                   image_html = v.image_tag(thumb_url, class: 'img-thumbnail')
                   url != thumb_url ? v.link_to(image_html, url, target: '_blank', rel: 'noopener noreferrer') : image_html
                 else
-                  v.link_to(value, url, target: '_blank', rel: 'noopener noreferrer')
+                  display_value = value.respond_to?(:filename) ? value.filename : value
+                  v.link_to(display_value, url, target: '_blank', rel: 'noopener noreferrer')
                 end
               end
             end

--- a/spec/rails_admin/config/fields/types/multiple_active_storage_spec.rb
+++ b/spec/rails_admin/config/fields/types/multiple_active_storage_spec.rb
@@ -7,10 +7,34 @@ RSpec.describe RailsAdmin::Config::Fields::Types::MultipleActiveStorage do
   let(:field) do
     RailsAdmin.config('FieldTest').fields.detect do |f|
       f.name == :active_storage_assets
-    end.with(object: record)
+    end.with(
+      object: record,
+      view: ApplicationController.new.view_context,
+    )
   end
 
   describe RailsAdmin::Config::Fields::Types::MultipleActiveStorage::ActiveStorageAttachment do
+    describe '#pretty_value' do
+      subject { field.pretty_value }
+
+      context 'when attachment is not an image' do
+        let(:record) { FactoryBot.create :field_test, active_storage_assets: [{io: StringIO.new('dummy'), filename: "test.txt", content_type: "text/plain"}] }
+
+        it 'uses filename as link text' do
+          expect(Nokogiri::HTML(subject).text).to eq 'test.txt'
+        end
+      end
+
+      context 'when the field is an image' do
+        let(:record) { FactoryBot.create :field_test, active_storage_assets: [{io: StringIO.new('dummy'), filename: "test.jpg", content_type: "image/jpeg"}] }
+
+        it 'shows thumbnail image with a link' do
+          expect(Nokogiri::HTML(subject).css('img').attribute('src').value).to match(%r{rails/active_storage/representations})
+          expect(Nokogiri::HTML(subject).css('a').attribute('href').value).to match(%r{rails/active_storage/blobs})
+        end
+      end
+    end
+
     describe '#image?' do
       context 'when attachment is an image' do
         let(:record) { FactoryBot.create :field_test, active_storage_assets: [{io: StringIO.new('dummy'), filename: "test.jpg", content_type: "image/jpeg"}] }


### PR DESCRIPTION
## Show Correct File Name For Multiple Attachments

Now multiple attachments of ActiveStroage with show `ActiveStroage object` when the attachment is not an image.
Fix to show it with the `filename`.

