### PR TITLE
Fix for enums where keys and values differ

### DIFF
--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -19,6 +19,16 @@ module RailsAdmin
             bindings[:object].class.respond_to?(enum_method) ? bindings[:object].class.send(enum_method) : bindings[:object].send(enum_method)
           end
 
+          register_instance_option :formatted_value do
+            if enum.is_a?(::Hash)
+              enum[value]
+            elsif enum.is_a?(::Array) && enum.first.is_a?(::Array)
+              enum.detect { |e| e[0].to_s == value.to_s }[1].to_s.presence || value.presence || ' - '
+            else
+              value.presence || ' - '
+            end
+          end
+
           register_instance_option :pretty_value do
             if enum.is_a?(::Hash)
               enum.reject { |_k, v| v.to_s != value.to_s }.keys.first.to_s.presence || value.presence || ' - '

--- a/spec/dummy_app/app/active_record/field_test.rb
+++ b/spec/dummy_app/app/active_record/field_test.rb
@@ -34,7 +34,7 @@ class FieldTest < ActiveRecord::Base
 
   has_rich_text :action_text_field if defined?(ActionText)
 
-  enum string_enum_field: {S: 's', M: 'm', L: 'l'}
+  enum string_enum_field: {SMALL: 's', MEDIUM: 'm', LARGE: 'l'}
   enum integer_enum_field: [:small, :medium, :large]
 
   validates :string_field, exclusion: {in: ['Invalid']} # to test file upload caching

--- a/spec/integration/fields/active_record_enum_spec.rb
+++ b/spec/integration/fields/active_record_enum_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'ActiveRecordEnum field', type: :request, active_record: true do
       RailsAdmin.config FieldTest do
         edit do
           field :string_enum_field do
-            default_value 'M'
+            default_value 'MEDIUM'
           end
         end
       end
@@ -18,19 +18,22 @@ RSpec.describe 'ActiveRecordEnum field', type: :request, active_record: true do
       visit new_path(model_name: 'field_test')
       is_expected.to have_selector('.enum_type select')
       is_expected.not_to have_selector('.enum_type select[multiple]')
-      expect(all('.enum_type option').map(&:text).select(&:present?)).to eq %w(S M L)
+      expect(all('.enum_type option').map(&:text).select(&:present?)).to eq %w(SMALL MEDIUM LARGE)
     end
 
     it 'shows current value as selected' do
-      visit edit_path(model_name: 'field_test', id: FieldTest.create(string_enum_field: 'L'))
+      field_test = FieldTest.create(string_enum_field: 'LARGE')
+      puts field_test.string_enum_field
+      puts field_test.attributes
+      visit edit_path(model_name: 'field_test', id: field_test)
       expect(find('.enum_type select').value).to eq 'l'
     end
 
     it 'can be updated' do
-      visit edit_path(model_name: 'field_test', id: FieldTest.create(string_enum_field: 'S'))
-      select 'L'
+      visit edit_path(model_name: 'field_test', id: FieldTest.create(string_enum_field: 'SMALL'))
+      select 'LARGE'
       click_button 'Save'
-      expect(FieldTest.first.string_enum_field).to eq 'L'
+      expect(FieldTest.first.string_enum_field).to eq 'LARGE'
     end
 
     it 'pre-populates default value' do


### PR DESCRIPTION
If the enums are defined with different values on the database, the current implementation doesn't show the value selected when editing a field.
This patch includes a regression by changing the existing keys for the enum field