### PR TITLE
update  coveralls to 0.8.23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ end
 group :test do
   gem 'cancancan', '~> 3.0'
   gem 'carrierwave', ['>= 2.0.0.rc', '< 3']
-  gem 'coveralls'
+  gem 'coveralls', '~> 0.8.23'
   gem 'database_cleaner', ['>= 1.2', '!= 1.4.0', '!= 1.5.0']
   gem 'dragonfly', '~> 1.0'
   gem 'factory_bot', '>= 4.2'

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -30,7 +30,7 @@ end
 group :test do
   gem "cancancan", "~> 2.0"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "coveralls"
+  gem "coveralls", "~> 0.8.23"
   gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0"]
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -31,7 +31,7 @@ end
 group :test do
   gem "cancancan", "~> 2.0"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "coveralls"
+  gem "coveralls", "~> 0.8.23"
   gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0"]
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -31,7 +31,7 @@ end
 group :test do
   gem "cancancan", "~> 2.0"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "coveralls"
+  gem "coveralls", "~> 0.8.23"
   gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0"]
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -31,7 +31,7 @@ end
 group :test do
   gem "cancancan", "~> 3.0"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "coveralls"
+  gem "coveralls", "~> 0.8.23"
   gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0"]
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"


### PR DESCRIPTION
fix the error of Coveralls when run travis job
```
Coveralls encountered an exception:
NoMethodError
undefined method `coverage' for #<SimpleCov:...
```
(https://travis-ci.org/github/sferik/rails_admin/jobs/734694843#L762-L775)
