### PR TITLE
Fix encoding detection error for MySQL applications using a connection proxy

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -75,7 +75,7 @@ module RailsAdmin
         when 'postgresql'
           ::ActiveRecord::Base.connection.select_one("SELECT ''::text AS str;").values.first.encoding
         when 'mysql2'
-          ::ActiveRecord::Base.connection.instance_variable_get(:@connection).encoding
+          ::ActiveRecord::Base.connection.raw_connection.encoding
         when 'oracle_enhanced'
           ::ActiveRecord::Base.connection.select_one("SELECT dummy FROM DUAL").values.first.encoding
         else


### PR DESCRIPTION
### Issue

Applications using MySQL with DB connection proxies (seen when using [active_record_host_pool](https://github.com/zendesk/active_record_host_pool/blob/76c244ddb1d7b5736fe0d043b98e33026b9c170f/lib/active_record_host_pool/connection_proxy.rb), but may apply to others that employ the same pattern) cannot currently use RailsAdmin's export feature, as `instance_variable_get` returns `nil` - resulting in a `NoMethodError` when `#encoding` is called [from the template](https://github.com/sferik/rails_admin/blob/73ac02f7c375f2f446ceb212615ef9056c9cd587/app/views/rails_admin/main/export.html.haml#L59) after a user clicks to export from a list.

### Proposed change
`raw_connection` returns the same connection as the `@connection` instance variable, and works with `Delegator`s that wrap the connection. `raw_connection` itself is [supported across all maintained versions of Rails](https://apidock.com/rails/v6.0.0/ActiveRecord/ConnectionAdapters/AbstractAdapter/raw_connection), and resolves the issue mentioned above.