### PR TITLE
Multi select Search Placeholder Fix

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -19,13 +19,13 @@
       sortable: false,
       removable: true,
       regional: {
-        add: "Add",
-        chooseAll: "Choose all",
-        clearAll: "Clear all",
-        down: "Down",
-        remove: "Remove",
-        search: "Search",
-        up: "Up"
+        add: 'Add',
+        chooseAll: 'Choose all',
+        clearAll: 'Clear all',
+        down: 'Down',
+        remove: 'Remove',
+        search: 'Search',
+        up: 'Up'
       },
       searchDelay: 400,
       remote_source: null,

--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -19,13 +19,14 @@
       sortable: false,
       removable: true,
       regional: {
-        up: "Up",
-        down: "Down",
         add: "Add",
         chooseAll: "Choose all",
         chosen: "Chosen records",
         clearAll: "Clear all",
-        remove: "Remove"
+        down: "Down",
+        remove: "Remove",
+        search: "Search",
+        up: "Up"
       },
       searchDelay: 400,
       remote_source: null,

--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -21,7 +21,6 @@
       regional: {
         add: "Add",
         chooseAll: "Choose all",
-        chosen: "Chosen records",
         clearAll: "Clear all",
         down: "Down",
         remove: "Remove",

--- a/app/assets/javascripts/rails_admin/ra.widgets.js
+++ b/app/assets/javascripts/rails_admin/ra.widgets.js
@@ -43,6 +43,7 @@
       });
       content.find('[data-enumeration]').each(function() {
         if ($(this).is('[multiple]')) {
+          console.log('WidgetJS', $(this).data('options'));
           $(this).filteringMultiselect($(this).data('options'));
         } else {
           $(this).filteringSelect($(this).data('options'));

--- a/app/assets/javascripts/rails_admin/ra.widgets.js
+++ b/app/assets/javascripts/rails_admin/ra.widgets.js
@@ -43,7 +43,6 @@
       });
       content.find('[data-enumeration]').each(function() {
         if ($(this).is('[multiple]')) {
-          console.log('WidgetJS', $(this).data('options'));
           $(this).filteringMultiselect($(this).data('options'));
         } else {
           $(this).filteringSelect($(this).data('options'));

--- a/app/views/rails_admin/main/_form_enumeration.html.haml
+++ b/app/views/rails_admin/main/_form_enumeration.html.haml
@@ -8,7 +8,6 @@
       cacheAll: true,
       regional: {
         chooseAll: t("admin.misc.chose_all"),
-        chosen: t("admin.misc.chosen", name: config.label_plural),
         clearAll: t("admin.misc.clear_all"),
         search: t("admin.misc.search"),
         up: t("admin.misc.up"),

--- a/app/views/rails_admin/main/_form_enumeration.html.haml
+++ b/app/views/rails_admin/main/_form_enumeration.html.haml
@@ -7,11 +7,13 @@
       sortable: false,
       cacheAll: true,
       regional: {
+        add: t("admin.misc.add_new"),
         chooseAll: t("admin.misc.chose_all"),
         clearAll: t("admin.misc.clear_all"),
+        down: t("admin.misc.down"),
+        remove: t("admin.misc.remove"),
         search: t("admin.misc.search"),
-        up: t("admin.misc.up"),
-        down: t("admin.misc.down")
+        up: t("admin.misc.up")
       }
     }
   = form.select field.method_name, field.enum, { selected: field.form_value, object: form.object }, field.html_attributes.reverse_merge({data: { filteringmultiselect: true, options: js_data.to_json }, multiple: true})

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -29,13 +29,13 @@
     removable: !!field.removable,
     cacheAll: !!field.associated_collection_cache_all,
     regional: {
-      add: t("admin.misc.add_new"),
-      chooseAll: t("admin.misc.chose_all"),
-      clearAll: t("admin.misc.clear_all"),
-      down: t("admin.misc.down"),
-      remove: t("admin.misc.remove"),
-      search: t("admin.misc.search"),
-      up: t("admin.misc.up")
+      add: t('admin.misc.add_new'),
+      chooseAll: t('admin.misc.chose_all'),
+      clearAll: t('admin.misc.clear_all'),
+      down: t('admin.misc.down'),
+      remove: t('admin.misc.remove'),
+      search: t('admin.misc.search'),
+      up: t('admin.misc.up')
     }
   }
 

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -29,12 +29,14 @@
     removable: !!field.removable,
     cacheAll: !!field.associated_collection_cache_all,
     regional: {
+      add: t("admin.misc.add_new"),
       chooseAll: t("admin.misc.chose_all"),
       chosen: t("admin.misc.chosen", name: config.label_plural),
       clearAll: t("admin.misc.clear_all"),
+      down: t("admin.misc.down"),
+      remove: t("admin.misc.remove"),
       search: t("admin.misc.search"),
-      up: t("admin.misc.up"),
-      down: t("admin.misc.down")
+      up: t("admin.misc.up")
     }
   }
 

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -31,7 +31,6 @@
     regional: {
       add: t("admin.misc.add_new"),
       chooseAll: t("admin.misc.chose_all"),
-      chosen: t("admin.misc.chosen", name: config.label_plural),
       clearAll: t("admin.misc.clear_all"),
       down: t("admin.misc.down"),
       remove: t("admin.misc.remove"),

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -36,7 +36,6 @@ en:
       bulk_menu_title: "Selected items"
       remove: "Remove"
       add_new: "Add new"
-      chosen: "Chosen %{name}"
       chose_all: "Choose all"
       clear_all: "Clear all"
       up: "Up"


### PR DESCRIPTION
While trying to translate the multi select, I stumbled over an `undefined` search placeholder for the input field.
I found out it was a combination of a missing translation option in a plugin and a missing default option text in rails_admin.

This is why I added the missing default translation option for the multi select js.