### PR TITLE
Enhancement: Default filter operator for fields

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -130,7 +130,7 @@ Lint/UnneededSplatExpansion:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 1081
+  Max: 1090
 
 # Offense count: 7
 Naming/AccessorMethodName:

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -76,7 +76,7 @@ module RailsAdmin
         options[:type]  = field.type
         options[:value] = filter_hash['v']
         options[:label] = field.label
-        options[:operator] = filter_hash['o']
+        options[:operator] = filter_hash['o'] || field.default_filter_operator
         options
       end if ordered_filters
     end

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -35,7 +35,7 @@
           - else
             - ''
           %li
-            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-options" => field_options.html_safe, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => (field.try(:parser) && field.parser.to_momentjs)}= capitalize_first_letter(field.label)
+            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-operator" => field.default_filter_operator, :"data-field-options" => field_options.html_safe, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => (field.try(:parser) && field.parser.to_momentjs)}= capitalize_first_letter(field.label)
 
 %style
   - properties.select{ |p| p.column_width.present? }.each do |property|

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -227,6 +227,10 @@ module RailsAdmin
           bindings[:view].render partial: "rails_admin/main/#{partial}", locals: {field: self, form: bindings[:form]}
         end
 
+        register_instance_option :default_filter_operator do
+          'default'
+        end
+
         def editable?
           !(@properties && @properties.read_only?)
         end

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -228,7 +228,7 @@ module RailsAdmin
         end
 
         register_instance_option :default_filter_operator do
-          'default'
+          nil
         end
 
         def editable?

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -286,6 +286,9 @@ RSpec.describe 'Index action', type: :request do
         field :name do
           default_filter_operator 'is'
         end
+        field :team do
+          filterable true
+        end
       end
       visit index_path(model_name: 'player')
 

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -283,6 +283,9 @@ RSpec.describe 'Index action', type: :request do
     it 'displays base filters when no filters are present in the params' do
       RailsAdmin.config Player do
         list { filters([:name, :team]) }
+        field :name do
+          default_filter_operator 'is'
+        end
       end
       visit index_path(model_name: 'player')
 
@@ -293,7 +296,7 @@ RSpec.describe 'Index action', type: :request do
           name: 'name',
           type: 'string',
           value: '',
-          operator: nil,
+          operator: 'is',
         },
         {
           index: 2,

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -556,4 +556,21 @@ RSpec.describe RailsAdmin::Config::Fields::Base do
       expect(RailsAdmin.config(Team).field(:name).allowed_methods).to eq [:name]
     end
   end
+
+  describe '#default_filter_operator' do
+    it 'has a default and be user customizable' do
+      RailsAdmin.config Team do
+        list do
+          field :division
+          field :name do
+            default_filter_operator 'is'
+          end
+        end
+      end
+      name_field = RailsAdmin.config('Team').list.fields.detect { |f| f.name == :name }
+      expect(name_field.default_filter_operator).to eq('is') # custom via user specification
+      division_field = RailsAdmin.config('Team').list.fields.detect { |f| f.name == :division }
+      expect(division_field.default_filter_operator).to eq('default') # rails_admin generic fallback
+    end
+  end
 end

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe RailsAdmin::Config::Fields::Base do
       name_field = RailsAdmin.config('Team').list.fields.detect { |f| f.name == :name }
       expect(name_field.default_filter_operator).to eq('is') # custom via user specification
       division_field = RailsAdmin.config('Team').list.fields.detect { |f| f.name == :division }
-      expect(division_field.default_filter_operator).to eq('default') # rails_admin generic fallback
+      expect(division_field.default_filter_operator).to be nil # rails_admin generic fallback
     end
   end
 end


### PR DESCRIPTION
**Issue**
When a filter is initially added on the filter criteria on a list view, the default operator is `nil` or empty which makes it necessary for the user to select an operator each time they add a filter.  This can be a bit cumbersome especially if users search a field by a particular operator the majority of the time.

**Proposed change**
A field option to set a default filter operator for a field which populates the filter operator select box when initially added to the filter criteria.  If one is not specified then it will default to the original behavior of setting the operator to `nil` or empty.