### PR TITLE
Hide present / blank filter options for required fields

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,6 +131,8 @@ Lint/UnneededSplatExpansion:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 1081
+  Exclude:
+    - 'spec/integration/actions/index_spec.rb'
 
 # Offense count: 7
 Naming/AccessorMethodName:

--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -11,6 +11,7 @@
       var field_value = options['value'];
       var field_operator = options['operator'];
       var select_options = options['select_options'];
+      var required = options['required'];
       var index = options['index'];
       var value_name    = 'f[' +  field_name + '][' + index + '][v]';
       var operator_name = 'f[' +  field_name + '][' + index + '][o]';
@@ -24,9 +25,13 @@
             .append('<option value="_discard">...</option>')
             .append($('<option value="true"></option>').prop('selected', field_value == "true").text(RailsAdmin.I18n.t("true")))
             .append($('<option value="false"></option>').prop('selected', field_value == "false").text(RailsAdmin.I18n.t("false")))
-            .append('<option disabled="disabled">---------</option>')
-            .append($('<option value="_present"></option>').prop('selected', field_value == "_present").text(RailsAdmin.I18n.t("is_present")))
-            .append($('<option value="_blank"></option>').prop('selected', field_value == "_blank").text(RailsAdmin.I18n.t("is_blank")));
+            if (!required) {
+              control.append([
+                '<option disabled="disabled">---------</option>',
+                $('<option value="_present"></option>').prop('selected', field_value == "_present").text(RailsAdmin.I18n.t("is_present")),
+                $('<option value="_blank"></option>').prop('selected', field_value == "_blank").text(RailsAdmin.I18n.t("is_blank"))
+              ])
+            }
           break;
         case 'date':
           additional_control =
@@ -56,9 +61,13 @@
             .append($('<option value="yesterday"></option>').prop('selected', field_operator == "yesterday").text(RailsAdmin.I18n.t("yesterday")))
             .append($('<option value="this_week"></option>').prop('selected', field_operator == "this_week").text(RailsAdmin.I18n.t("this_week")))
             .append($('<option value="last_week"></option>').prop('selected', field_operator == "last_week").text(RailsAdmin.I18n.t("last_week")))
-            .append('<option disabled="disabled">---------</option>')
-            .append($('<option value="_not_null"></option>').prop('selected', field_operator == "_not_null").text(RailsAdmin.I18n.t("is_present")))
-            .append($('<option value="_null"></option>').prop('selected', field_operator == "_null").text(RailsAdmin.I18n.t("is_blank")));
+          if (!required) {
+            control.append([
+              '<option disabled="disabled">---------</option>',
+              $('<option value="_not_null"></option>').prop('selected', field_operator == "_not_null").text(RailsAdmin.I18n.t("is_present")),
+              $('<option value="_null"></option>').prop('selected', field_operator == "_null").text(RailsAdmin.I18n.t("is_blank"))
+            ])
+          }
           additional_control = additional_control ||
             $('<input size="25" class="datetime additional-fieldset default input-sm form-control" type="text" />')
             .css('display', (!field_operator || field_operator == "default") ? 'inline-block' : 'none')
@@ -84,10 +93,14 @@
             .prop('name', multiple_values ? undefined : value_name)
             .data('name', value_name)
             .append('<option value="_discard">...</option>')
-            .append($('<option value="_present"></option>').prop('selected', field_value == "_present").text(RailsAdmin.I18n.t("is_present")))
-            .append($('<option value="_blank"></option>').prop('selected', field_value == "_blank").text(RailsAdmin.I18n.t("is_blank")))
-            .append('<option disabled="disabled">---------</option>')
-            .append(select_options)
+          if (!required) {
+            control.append([
+              $('<option value="_present"></option>').prop('selected', field_value == "_present").text(RailsAdmin.I18n.t("is_present")),
+              $('<option value="_blank"></option>').prop('selected', field_value == "_blank").text(RailsAdmin.I18n.t("is_blank")),
+              '<option disabled="disabled">---------</option>'
+            ])
+          }
+          control.append(select_options)
             .add(
               $('<select multiple="multiple" class="select-multiple input-sm form-control"></select>')
               .css('display', multiple_values ? 'inline-block' : 'none')
@@ -111,9 +124,13 @@
             .append($('<option data-additional-fieldset="additional-fieldset" value="is"></option>').prop('selected', field_operator == "is").text(RailsAdmin.I18n.t("is_exactly")))
             .append($('<option data-additional-fieldset="additional-fieldset" value="starts_with"></option>').prop('selected', field_operator == "starts_with").text(RailsAdmin.I18n.t("starts_with")))
             .append($('<option data-additional-fieldset="additional-fieldset" value="ends_with"></option>').prop('selected', field_operator == "ends_with").text(RailsAdmin.I18n.t("ends_with")))
-            .append('<option disabled="disabled">---------</option>')
-            .append($('<option value="_present"></option>').prop('selected', field_operator == "_present").text(RailsAdmin.I18n.t("is_present")))
-            .append($('<option value="_blank"></option>').prop('selected', field_operator == "_blank").text(RailsAdmin.I18n.t("is_blank")));
+          if (!required) {
+            control.append([
+              '<option disabled="disabled">---------</option>',
+              $('<option value="_present"></option>').prop('selected', field_operator == "_present").text(RailsAdmin.I18n.t("is_present")),
+              $('<option value="_blank"></option>').prop('selected', field_operator == "_blank").text(RailsAdmin.I18n.t("is_blank"))
+            ])
+          }
           additional_control = $('<input class="additional-fieldset input-sm form-control" type="text" />')
             .css('display', field_operator == "_present" || field_operator == "_blank" ? 'none' : 'inline-block')
             .prop('name', value_name)
@@ -126,9 +143,13 @@
             .prop('name', operator_name)
             .append($('<option data-additional-fieldset="default" value="default"></option>').prop('selected', field_operator == "default").text(RailsAdmin.I18n.t("number")))
             .append($('<option data-additional-fieldset="between" value="between"></option>').prop('selected', field_operator == "between").text(RailsAdmin.I18n.t("between_and_")))
-            .append('<option disabled="disabled">---------</option>')
-            .append($('<option value="_not_null"></option>').prop('selected', field_operator == "_not_null").text(RailsAdmin.I18n.t("is_present")))
-            .append($('<option value="_null"></option>').prop('selected', field_operator == "_null").text(RailsAdmin.I18n.t("is_blank")));
+          if (!required) {
+            control.append([
+              '<option disabled="disabled">---------</option>',
+              $('<option value="_not_null"></option>').prop('selected', field_operator == "_not_null").text(RailsAdmin.I18n.t("is_present")),
+              $('<option value="_null"></option>').prop('selected', field_operator == "_null").text(RailsAdmin.I18n.t("is_blank"))
+            ])
+          }
           additional_control =
             $('<input class="additional-fieldset default input-sm form-control" type="text" />')
             .css('display', (!field_operator || field_operator == "default") ? 'inline-block' : 'none')
@@ -193,6 +214,7 @@
       value: $(this).data('field-value'),
       operator: $(this).data('field-operator'),
       select_options: $(this).data('field-options'),
+      required: $(this).data('field-required'),
       index: $.now().toString().slice(6,11),
       datetimepicker_format: $(this).data('field-datetimepicker-format')
     });

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -77,6 +77,7 @@ module RailsAdmin
         options[:value] = filter_hash['v']
         options[:label] = field.label
         options[:operator] = filter_hash['o']
+        options[:required] = field.required
         options
       end if ordered_filters
     end

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -35,7 +35,7 @@
           - else
             - ''
           %li
-            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-options" => field_options.html_safe, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => (field.try(:parser) && field.parser.to_momentjs)}= capitalize_first_letter(field.label)
+            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-options" => field_options.html_safe, :"data-field-required" => field.required.to_s, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => (field.try(:parser) && field.parser.to_momentjs)}= capitalize_first_letter(field.label)
 
 %style
   - properties.select{ |p| p.column_width.present? }.each do |property|

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -59,6 +59,27 @@ RSpec.describe 'Index action', type: :request do
       @comment = FactoryBot.create(:comment, commentable: @players[2])
     end
 
+    it 'hides redundant filter options for required fields', js: true do
+      RailsAdmin.config Player do
+        list do
+          field :name do
+            required true
+          end
+          field :team
+        end
+      end
+
+      visit index_path(model_name: 'player', f: {name: {'1' => {v: ''}}, team: {'2' => {v: ''}}})
+
+      within(:select, name: 'f[name][1][o]') do
+        expect(page.all('option').map(&:value)).to_not include('_present', '_blank')
+      end
+
+      within(:select, name: 'f[team][2][o]') do
+        expect(page.all('option').map(&:value)).to include('_present', '_blank')
+      end
+    end
+
     it 'allows to query on any attribute' do
       RailsAdmin.config Player do
         list do
@@ -294,6 +315,7 @@ RSpec.describe 'Index action', type: :request do
           type: 'string',
           value: '',
           operator: nil,
+          required: true,
         },
         {
           index: 2,
@@ -302,6 +324,7 @@ RSpec.describe 'Index action', type: :request do
           type: 'belongs_to_association',
           value: '',
           operator: nil,
+          required: false,
         },
       ]
     end


### PR DESCRIPTION
### Issue

For cases where a field is required (via validations, model config, or otherwise) and filterable, the associated filter dropdown includes `present` and `blank` options that are unnecessary as the field is always expected to be present.

### Proposed change

Pass the `required` field from the model through to the filter box javascript, keeping the existing order but only appending the `present` and `blank` options when the field is not required.

📝 I'm not sure how to best test the `js` changes aside from the tests added to `index_spec.rb` (which put it over the `rubocop` TODO limit, so I added that file as an exception instead of bumping the max any further).

---

Example using the spec `dummy_app`

#### Required field (`name`)
<img width="513" alt="Screen Shot 2021-02-18 at 15 34 33" src="https://user-images.githubusercontent.com/4504083/108435706-db4fbd00-71fe-11eb-9587-22effa2836d9.png">

#### Optional field (`team`)
<img width="508" alt="Screen Shot 2021-02-18 at 15 34 47" src="https://user-images.githubusercontent.com/4504083/108435718-e4408e80-71fe-11eb-88c9-52350510b54a.png">
