### PR TITLE
Update database cleaner to >= 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ end
 group :test do
   gem 'cancancan', '~> 3.0'
   gem 'carrierwave', ['>= 2.0.0.rc', '< 3']
-  gem 'database_cleaner', ['>= 1.2', '!= 1.4.0', '!= 1.5.0', '< 2.0']
+  gem 'database_cleaner-mongoid', '>= 2.0', require: false
+  gem 'database_cleaner-active_record', '>= 2.0', require: false
   gem 'dragonfly', '~> 1.0'
   gem 'factory_bot', '>= 4.2'
   gem 'generator_spec', '>= 0.8'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -32,7 +32,8 @@ end
 group :test do
   gem "cancancan", "~> 3.0"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0", "< 2.0"]
+  gem "database_cleaner-mongoid", ">= 2.0", require: false
+  gem "database_cleaner-active_record", ">= 2.0", require: false
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"
   gem "generator_spec", ">= 0.8"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -32,7 +32,8 @@ end
 group :test do
   gem "cancancan", "~> 3.2"
   gem "carrierwave", [">= 2.0.0.rc", "< 3"]
-  gem "database_cleaner", [">= 1.2", "!= 1.4.0", "!= 1.5.0", "< 2.0"]
+  gem "database_cleaner-mongoid", ">= 2.0", require: false
+  gem "database_cleaner-active_record", ">= 2.0", require: false
   gem "dragonfly", "~> 1.0"
   gem "factory_bot", ">= 4.2"
   gem "generator_spec", ">= 0.8"

--- a/spec/orm/active_record.rb
+++ b/spec/orm/active_record.rb
@@ -1,7 +1,5 @@
 require 'rails_admin/adapters/active_record'
 
-DatabaseCleaner.strategy = :transaction
-
 ActiveRecord::Base.connection.data_sources.each do |table|
   ActiveRecord::Base.connection.drop_table(table)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require 'rspec/rails'
 require 'factory_bot'
 require 'factories'
 require 'policies'
-require 'database_cleaner'
+require "database_cleaner/#{CI_ORM}"
 require "orm/#{CI_ORM}"
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__),
@@ -93,7 +93,7 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    DatabaseCleaner.strategy = (CI_ORM == :mongoid || example.metadata[:js]) ? :truncation : :transaction
+    DatabaseCleaner.strategy = (CI_ORM == :mongoid || example.metadata[:js]) ? :deletion : :transaction
 
     DatabaseCleaner.start
     RailsAdmin::Config.reset


### PR DESCRIPTION
Followup to https://github.com/sferik/rails_admin/pull/3341

[Related changes to `database_cleaner` gem](https://github.com/DatabaseCleaner/database_cleaner/blob/master/History.rdoc#200beta-2020-04-05-)

`database_cleaner` was split into separate adapter gems - the two needed for this project are:
- [`database_cleaner-active_record`](https://github.com/DatabaseCleaner/database_cleaner-active_record)
- [`database_cleaner-mongoid`](https://github.com/DatabaseCleaner/database_cleaner-mongoid)

This also removes Ruby 2.2 from the CI build, since `database_cleaner` uses the safe navigation operator which was introduced in Ruby 2.3 (see [related CI failure here](https://github.com/codealchemy/rails_admin/runs/1949121193?check_suite_focus=true)). Maintaining a Ruby 2.2 build has caused issues elsewhere as well (see related discussion in https://github.com/sferik/rails_admin/pull/3256#issuecomment-608205133), and 2.2 itself is no longer maintained as of [March, 2018](https://www.ruby-lang.org/en/downloads/branches/).