### PR TITLE
Remove unnecessary Devise patch

### DIFF
--- a/config/initializers/devise_patch.rb
+++ b/config/initializers/devise_patch.rb
@@ -1,9 +1,0 @@
-if defined?(::Devise)
-  module Devise
-    class FailureApp
-      def scope
-        @scope ||= warden_options[:scope] || Devise.default_scope
-      end
-    end
-  end
-end


### PR DESCRIPTION
Originally added in https://github.com/sferik/rails_admin/commit/db0697975dd7fbb4473c145af42a5374a95f0472, this matches [what's upstream in Devise](https://github.com/heartcombo/devise/blob/e8e0c275999dd98150197cab03acb5509cb16b6a/lib/devise/failure_app.rb#L226-L228) (which was added in https://github.com/heartcombo/devise/commit/17ec0c08edd0d5ee216105aeef741670fb28ac5a) so this patch appears to no longer be needed.