### PR TITLE
Support alternative paper_trail versions association name

### DIFF
--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -116,7 +116,7 @@ module RailsAdmin
 
           current_page = page.presence || '1'
 
-          versions = object.nil? ? versions_for_model(model) : object.versions
+          versions = object.nil? ? versions_for_model(model) : object.public_send(model.model.versions_association_name)
           versions = versions.where('event LIKE ?', "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == 'true' ? "#{sort} DESC" : sort)
           versions = all ? versions : versions.send(Kaminari.config.page_method_name, current_page).per(per_page)


### PR DESCRIPTION
When using PaperTrail as an auditing gem, you can specify an alternative versions association by defining the `versions` hash in the `has_paper_trail` call. Initialization of PaperTrail (per model) stores the name of the association (since https://github.com/paper-trail-gem/paper_trail/commit/3032b53, 23rd of July 2011) in `versions_association_name`. Using this method we can retrieve the history of a model when it uses a different name for the versions association.

For example, using the following configuration won't break the auditing_adapter with this change:
```ruby
has_paper_trail(
  version: :paper_trail_version,
  versions: {
    name: :paper_trail_versions,
  },
)
```