### PR TITLE
Fix missing select options for enum filters

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -98,6 +98,7 @@
               $('<option value="_blank"></option>').prop('selected', field_value == "_blank").text(RailsAdmin.I18n.t("is_blank")),
               '<option disabled="disabled">---------</option>'
             ])
+            .append(select_options)
             .add(
               $('<select multiple="multiple" class="select-multiple input-sm form-control"></select>')
               .css('display', multiple_values ? 'inline-block' : 'none')

--- a/spec/integration/fields/enum_spec.rb
+++ b/spec/integration/fields/enum_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe 'Enum field', type: :request, active_record: true do
       visit index_path(model_name: 'team')
       click_link 'Add filter'
       click_link 'Color'
-      is_expected.to have_selector('.filter .switch-select .icon-plus')
+      expect(all('.select-single option').map(&:text)).to include 'blue', 'green', 'red'
+      find('.filter .switch-select .icon-plus').click
+      expect(all('.select-multiple option').map(&:text)).to include 'blue', 'green', 'red'
     end
   end
 


### PR DESCRIPTION
Following https://github.com/sferik/rails_admin/commit/555f7783f2255ddc736141c410c5bdaee074887a, the (single) select dropdown for `enum`s no longer includes the available values (though multiselect still works)

This ensures we append the available enum options to the single select dropdown.

### Before

<img width="786" alt="Screen Shot 2021-08-03 at 13 25 59" src="https://user-images.githubusercontent.com/4504083/128081435-160011fa-e2c5-4e8f-8fd7-47f04dd2f098.png">

### After

<img width="766" alt="Screen Shot 2021-08-03 at 13 26 14" src="https://user-images.githubusercontent.com/4504083/128081440-d416361c-c39e-4ea5-84c6-8c620fe43227.png">
