### PR TITLE
PaperTrail extension updates

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -13,7 +13,7 @@ appraise "rails-6.0" do
 
   group :active_record do
     gem 'pg', '>= 1.0.0', platforms: :ruby
-    gem 'paper_trail', '>= 5.0'
+    gem 'paper_trail', '>= 12.0'
 
     platforms :jruby do
       gem 'activerecord-jdbcmysql-adapter', '~> 60.0'
@@ -47,7 +47,7 @@ appraise "rails-6.1" do
 
   group :active_record do
     gem 'pg', '>= 1.0.0', platforms: :ruby
-    gem 'paper_trail', '>= 5.0'
+    gem 'paper_trail', '>= 12.0'
 
     platforms :jruby do
       gem 'activerecord-jdbcmysql-adapter', '~> 61.0'

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -149,7 +149,7 @@ module RailsAdmin
         # classes](https://github.com/paper-trail-gem/paper_trail#6a-custom-version-classes)
         #
         # ```ruby
-        # has_paper_trail class_name: 'MyVersion'
+        # has_paper_trail versions: { class_name: 'MyVersion' }
         # ```
         def version_class_for(model)
           model.paper_trail_options.dig(:versions, :class_name).try(:constantize) || @version_class

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -152,7 +152,7 @@ module RailsAdmin
         # has_paper_trail class_name: 'MyVersion'
         # ```
         def version_class_for(model)
-          model.paper_trail_options[:class_name].try(:constantize) || @version_class
+          model.paper_trail_options.dig(:versions, :class_name).try(:constantize) || @version_class
         end
       end
     end

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -15,7 +15,7 @@ group :active_record do
     gem 'sqlite3', '>= 1.3.0'
   end
 
-  gem 'paper_trail', '>= 5.0'
+  gem 'paper_trail', '>= 12.0'
 end
 
 group :mongoid do

--- a/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
@@ -1,4 +1,8 @@
+class Trail < PaperTrail::Version
+  self.table_name = :custom_versions
+end
+
 class PaperTrailTestWithCustomAssociation < ActiveRecord::Base
   self.table_name = :paper_trail_tests
-  has_paper_trail versions: {name: :trails}
+  has_paper_trail versions: {class_name: 'Trail'}
 end

--- a/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
@@ -1,8 +1,4 @@
 class PaperTrailTestWithCustomAssociation < ActiveRecord::Base
   self.table_name = :paper_trail_tests
-  if PaperTrail::VERSION::MAJOR >= 10
-    has_paper_trail versions: {name: :trails}
-  else
-    has_paper_trail versions: :trails
-  end
+  has_paper_trail versions: {name: :trails}
 end

--- a/spec/dummy_app/config/initializers/paper_trail.rb
+++ b/spec/dummy_app/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false if defined?(PaperTrail) && PaperTrail::VERSION::MAJOR < 10

--- a/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
+++ b/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
@@ -1,0 +1,13 @@
+class CreateCustomVersions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :custom_versions do |t|
+      t.string :item_type, null: false
+      t.integer :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.text :object
+      t.datetime :created_at
+    end
+    add_index :custom_versions, [:item_type, :item_id]
+  end
+end

--- a/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
+++ b/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
@@ -1,4 +1,4 @@
-class CreateCustomVersions < ActiveRecord::Migration[6.1]
+class CreateCustomVersions < ActiveRecord::Migration[5.0]
   def change
     create_table :custom_versions do |t|
       t.string :item_type, null: false

--- a/spec/integration/auditing/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/auditing/rails_admin_paper_trail_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'RailsAdmin PaperTrail auditing', active_record: true do
       end
 
       it 'creates versions' do
-        expect(PaperTrail::Version.count).to eq(30)
+        expect(paper_class_name.constantize.version_class_name.constantize.count).to eq(30)
       end
 
       describe 'model history fetch with auditing adapter' do


### PR DESCRIPTION
Following https://github.com/sferik/rails_admin/commit/decf4280183b8b6a453aa802942fc825524c2f13, this updates the PaperTrail adapter to
- Align the extension in dev / CI with [supported versions](https://github.com/paper-trail-gem/paper_trail#1a-compatibility)
- Remove unnecessary version checks
- Fix an existing 🐛 in the auditing adapter related to custom version class names