### PR TITLE
Add HTML5 validation for float-like field types

### DIFF
--- a/lib/rails_admin/config/fields/types/decimal.rb
+++ b/lib/rails_admin/config/fields/types/decimal.rb
@@ -1,16 +1,12 @@
-require 'rails_admin/config/fields/base'
+require 'rails_admin/config/fields/types/numeric'
 
 module RailsAdmin
   module Config
     module Fields
       module Types
-        class Decimal < RailsAdmin::Config::Fields::Base
+        class Decimal < RailsAdmin::Config::Fields::Types::Numeric
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
-
-          register_instance_option :view_helper do
-            :number_field
-          end
 
           register_instance_option :html_attributes do
             {

--- a/lib/rails_admin/config/fields/types/decimal.rb
+++ b/lib/rails_admin/config/fields/types/decimal.rb
@@ -7,6 +7,17 @@ module RailsAdmin
         class Decimal < RailsAdmin::Config::Fields::Base
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :view_helper do
+            :number_field
+          end
+
+          register_instance_option :html_attributes do
+            {
+              required: required?,
+              step: "any",
+            }
+          end
         end
       end
     end

--- a/lib/rails_admin/config/fields/types/float.rb
+++ b/lib/rails_admin/config/fields/types/float.rb
@@ -7,6 +7,17 @@ module RailsAdmin
         class Float < RailsAdmin::Config::Fields::Base
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :view_helper do
+            :number_field
+          end
+
+          register_instance_option :html_attributes do
+            {
+              required: required?,
+              step: "any",
+            }
+          end
         end
       end
     end

--- a/lib/rails_admin/config/fields/types/float.rb
+++ b/lib/rails_admin/config/fields/types/float.rb
@@ -1,16 +1,12 @@
-require 'rails_admin/config/fields/base'
+require 'rails_admin/config/fields/types/numeric'
 
 module RailsAdmin
   module Config
     module Fields
       module Types
-        class Float < RailsAdmin::Config::Fields::Base
+        class Float < RailsAdmin::Config::Fields::Types::Numeric
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
-
-          register_instance_option :view_helper do
-            :number_field
-          end
 
           register_instance_option :html_attributes do
             {

--- a/lib/rails_admin/config/fields/types/numeric.rb
+++ b/lib/rails_admin/config/fields/types/numeric.rb
@@ -1,15 +1,15 @@
-require 'rails_admin/config/fields/types/numeric'
+require 'rails_admin/config/fields/base'
 
 module RailsAdmin
   module Config
     module Fields
       module Types
-        class Integer < RailsAdmin::Config::Fields::Types::Numeric
+        class Numeric < RailsAdmin::Config::Fields::Base
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
 
-          register_instance_option :sort_reverse? do
-            serial?
+          register_instance_option :view_helper do
+            :number_field
           end
         end
       end

--- a/spec/rails_admin/config/fields/types/decimal_spec.rb
+++ b/spec/rails_admin/config/fields/types/decimal_spec.rb
@@ -1,23 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Decimal do
-  subject do
-    RailsAdmin.config('FieldTest').fields.detect do |f|
-      f.name == :decimal_field
-    end.with(object: FieldTest.new)
-  end
-
-  describe '#html_attributes' do
-    it 'should contain a step attribute' do
-      expect(subject.html_attributes[:step]).to eq('any')
-    end
-  end
-
-  describe '#view_helper' do
-    it "uses the 'number' type input tag" do
-      expect(subject.view_helper).to eq(:number_field)
-    end
-  end
-
-  it_behaves_like 'a generic field type', :decimal_field, :decimal
+  it_behaves_like 'a float-like field type', :float_field
 end

--- a/spec/rails_admin/config/fields/types/decimal_spec.rb
+++ b/spec/rails_admin/config/fields/types/decimal_spec.rb
@@ -1,5 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Decimal do
+  subject do
+    RailsAdmin.config('FieldTest').fields.detect do |f|
+      f.name == :decimal_field
+    end.with(object: FieldTest.new)
+  end
+
+  describe '#html_attributes' do
+    it 'should contain a step attribute' do
+      expect(subject.html_attributes[:step]).to eq('any')
+    end
+  end
+
+  describe '#view_helper' do
+    it "uses the 'number' type input tag" do
+      expect(subject.view_helper).to eq(:number_field)
+    end
+  end
+
   it_behaves_like 'a generic field type', :decimal_field, :decimal
 end

--- a/spec/rails_admin/config/fields/types/float_spec.rb
+++ b/spec/rails_admin/config/fields/types/float_spec.rb
@@ -1,5 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Float do
+  subject do
+    RailsAdmin.config('FieldTest').fields.detect do |f|
+      f.name == :float_field
+    end.with(object: FieldTest.new)
+  end
+
+  describe '#html_attributes' do
+    it 'should contain a step attribute' do
+      expect(subject.html_attributes[:step]).to eq('any')
+    end
+  end
+
+  describe '#view_helper' do
+    it "uses the 'number' type input tag" do
+      expect(subject.view_helper).to eq(:number_field)
+    end
+  end
+
   it_behaves_like 'a generic field type', :float_field, :float
 end

--- a/spec/rails_admin/config/fields/types/float_spec.rb
+++ b/spec/rails_admin/config/fields/types/float_spec.rb
@@ -1,23 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Float do
-  subject do
-    RailsAdmin.config('FieldTest').fields.detect do |f|
-      f.name == :float_field
-    end.with(object: FieldTest.new)
-  end
-
-  describe '#html_attributes' do
-    it 'should contain a step attribute' do
-      expect(subject.html_attributes[:step]).to eq('any')
-    end
-  end
-
-  describe '#view_helper' do
-    it "uses the 'number' type input tag" do
-      expect(subject.view_helper).to eq(:number_field)
-    end
-  end
-
-  it_behaves_like 'a generic field type', :float_field, :float
+  it_behaves_like 'a float-like field type', :float_field
 end

--- a/spec/rails_admin/config/fields/types/numeric_spec.rb
+++ b/spec/rails_admin/config/fields/types/numeric_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe RailsAdmin::Config::Fields::Types::Numeric do
+  it_behaves_like 'a generic field type', :integer_field, :integer
+
+  subject do
+    RailsAdmin.config('FieldTest').fields.detect do |f|
+      f.name == :integer_field
+    end.with(object: FieldTest.new)
+  end
+
+  describe '#view_helper' do
+    it "uses the 'number' type input tag" do
+      expect(subject.view_helper).to eq(:number_field)
+    end
+  end
+end

--- a/spec/shared_examples/shared_examples_for_field_types.rb
+++ b/spec/shared_examples/shared_examples_for_field_types.rb
@@ -34,3 +34,41 @@ RSpec.shared_examples 'a string-like field type' do |column_name, _|
     expect(subject).to be_a(RailsAdmin::Config::Fields::Types::StringLike)
   end
 end
+
+RSpec.shared_examples 'a float-like field type' do |column_name|
+  subject do
+    RailsAdmin.config('FieldTest').fields.detect do |f|
+      f.name == column_name
+    end.with(object: FieldTest.new)
+  end
+
+  describe '#html_attributes' do
+    it 'should contain a step attribute' do
+      expect(subject.html_attributes[:step]).to eq('any')
+    end
+
+    it 'should contain a falsey required attribute' do
+      expect(subject.html_attributes[:required]).to be_falsey
+    end
+
+    context 'when the field is required' do
+      before do
+        RailsAdmin.config FieldTest do
+          field column_name, :float do
+            required true
+          end
+        end
+      end
+
+      it 'should contain a truthy required attribute' do
+        expect(subject.html_attributes[:required]).to be_truthy
+      end
+    end
+  end
+
+  describe '#view_helper' do
+    it "uses the 'number' type input tag" do
+      expect(subject.view_helper).to eq(:number_field)
+    end
+  end
+end


### PR DESCRIPTION
`float` and `decimal` fields currently render as text inputs, allowing non-numerical values in the form.

This updates their respective form helper to be the [appropriate field type (number)](https://apidock.com/rails/v5.2.3/ActionView/Helpers/FormHelper/number_field), as well as the [`step` html attribute](https://www.w3.org/TR/2012/WD-html5-20121025/common-input-element-attributes.html#attr-input-step) to the most permissive for input validation.

Closes https://github.com/sferik/rails_admin/issues/3289