### PR TITLE
Update Boolean `pretty_value` to include default fallback

### DIFF
--- a/lib/rails_admin/config/fields/types/boolean.rb
+++ b/lib/rails_admin/config/fields/types/boolean.rb
@@ -12,12 +12,12 @@ module RailsAdmin
 
           register_instance_option :pretty_value do
             case value
-            when nil
-              %(<span class='label label-default'>&#x2012;</span>)
             when false
               %(<span class='label label-danger'>&#x2718;</span>)
             when true
               %(<span class='label label-success'>&#x2713;</span>)
+            else
+              %(<span class='label label-default'>&#x2012;</span>)
             end.html_safe
           end
 

--- a/spec/rails_admin/config/fields/types/boolean_spec.rb
+++ b/spec/rails_admin/config/fields/types/boolean_spec.rb
@@ -2,4 +2,27 @@ require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Boolean do
   it_behaves_like 'a generic field type', :boolean_field, :boolean
+
+  subject do
+    RailsAdmin.config(FieldTest).fields.detect do |f|
+      f.name == :boolean_field
+    end.with(object: test_object)
+  end
+
+  describe '#pretty_value' do
+    {
+      false => %(<span class='label label-danger'>&#x2718;</span>),
+      true => %(<span class='label label-success'>&#x2713;</span>),
+      nil => %(<span class='label label-default'>&#x2012;</span>),
+    }.each do |field_value, expected_result|
+
+      context "when field value is '#{field_value.inspect}'" do
+        let(:test_object) { FieldTest.new(boolean_field: field_value) }
+
+        it "returns the appropriate html result" do
+          expect(subject.pretty_value).to eq(expected_result)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I wasn't able to reproduce the 🐛 seen on #1852 on recent versions of `mongoid` / `MongoDB` (issue references `mongoid` v4, which was released roughly 7 years ago), so this may already be resolved in more recent versions of related dependencies. 

However, this change will at least prevent the interface from breaking in the event a boolean value doesn't match the explicit types checked in the `case` statement (closes https://github.com/sferik/rails_admin/issues/1852).

There's a related [Rubocop cop](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MissingElse) that would flag the missing `else` here as well (this cop is disabled by default).