### PR TITLE
Update file upload translations to avoid concatenation

### DIFF
--- a/app/views/rails_admin/main/_form_file_upload.html.haml
+++ b/app/views/rails_admin/main/_form_file_upload.html.haml
@@ -12,6 +12,6 @@
 - if field.optional? && field.errors.blank? && file && field.delete_method
   %a.btn.btn-info.btn-remove-image{href: '#', :'data-toggle' => 'button', role: 'button'}
     %i.icon-white.icon-trash
-    = I18n.t('admin.actions.delete.menu').capitalize + " #{field.label.downcase}"
+    = I18n.t('admin.actions.delete.link', object_label: field.label)
 
   = form.check_box(field.delete_method, style: 'display:none;')

--- a/app/views/rails_admin/main/_form_multiple_file_upload.html.haml
+++ b/app/views/rails_admin/main/_form_multiple_file_upload.html.haml
@@ -4,7 +4,7 @@
     - if field.delete_method || field.keep_method
       %a.btn.btn-info.btn-remove-image{href: '#', :'data-toggle' => 'button', role: 'button'}
         %i.icon-white.icon-trash
-        = I18n.t('admin.actions.delete.menu').capitalize + " #{field.label.downcase} ##{i + 1}"
+        = I18n.t('admin.form.delete_file', field_label: field.label, number: i + 1)
       - if field.keep_method
         = form.check_box(field.keep_method, {multiple:true, checked: true, style: 'display:none;'}, attachment.keep_value, nil)
       - elsif field.delete_method

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -127,6 +127,7 @@ en:
       save: "Save"
       save_and_add_another: "Save and add another"
       save_and_edit: "Save and edit"
+      delete_file: "Delete '%{field_label}' #%{number}"
       all_of_the_following_related_items_will_be_deleted: "? The following related items may be deleted or orphaned:"
       are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete this %{model_name}"
       confirmation: "Yes, I'm sure"

--- a/spec/integration/fields/multiple_carrierwave_spec.rb
+++ b/spec/integration/fields/multiple_carrierwave_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'MultipleCarrierwave field', type: :request, active_record: true 
 
     it 'supports deleting a file', js: true do
       visit edit_path(model_name: 'field_test', id: field_test.id)
-      click_link 'Delete carrierwave assets #1'
+      click_link "Delete 'Carrierwave assets' #1"
       click_button 'Save'
       field_test.reload
       expect(field_test.carrierwave_assets.map { |image| File.basename(image.url) }).to eq ['test.png']


### PR DESCRIPTION
This updates the file upload form translations to better align with i18n conventions (ie. avoid concatenating translations). 

Closes #3260