### PR TITLE
CI performance improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,15 +67,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Cache gems
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'gemfiles/*.gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-${{ matrix.ruby }}-
-    - name: Install dependencies
-      run: bundle install --without development --jobs=3 --retry=3 --path=vendor/bundle
+        bundler-cache: true
+        cache-version: gems-${{ hashFiles('Gemfile', 'gemfiles/*.gemfile') }}
+      env:
+        MAKE: make --jobs 4
+        BUNDLE_WITHOUT: development
     - name: Setup application
       env:
         BUNDLE_GEMFILE: ../../${{ matrix.gemfile }}


### PR DESCRIPTION
This skips the intermediate `Cache gems` / `Install dependencies` steps by enabling [`bundler-cache` in the `setup-ruby` action](https://github.com/ruby/setup-ruby#caching-bundle-install-automatically).

Additionally, the added `MAKE` env var improves the performance of building native extensions on MRI (borrowing the approach mentioned [here](https://build.betterup.com/one-weird-trick-that-will-speed-up-your-bundle-install/))

This up to roughly 1m30s per MRI build in the current CI matrix (and low-to-no improvement for `jruby` builds)