### PR TITLE
Switch GitHub Actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
             gemfile: gemfiles/rails_6.1.gemfile
             orm: mongoid
             adapter: sqlite3
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:8.0
@@ -94,7 +94,7 @@ jobs:
   coveralls:
     name: Coveralls
     needs: rspec
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
@@ -104,7 +104,7 @@ jobs:
 
   rubocop:
     name: RuboCop
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby


### PR DESCRIPTION
Fixes the following error when running actions on a fork:

    Can't find any online and idle self-hosted runner in the current repository, account/organization that matches the required labels: 'ubuntu-16.04'
    Waiting for a self-hosted runner to pickup this job...