### PR TITLE
Remove workaround for unsupported Rails 4

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -26,12 +26,8 @@ module RailsAdmin
 
     initializer 'RailsAdmin reload config in development' do
       if Rails.application.config.cache_classes
-        if defined?(ActiveSupport::Reloader)
-          ActiveSupport::Reloader.before_class_unload do
-            RailsAdmin::Config.reset_all_models
-          end
-          # else
-          # For Rails 4 not implemented
+        ActiveSupport::Reloader.before_class_unload do
+          RailsAdmin::Config.reset_all_models
         end
       end
     end


### PR DESCRIPTION
Rails 4 support was removed in rails_admin 2.0.