### PR TITLE
Simplify jquery-ui inclusion

### DIFF
--- a/app/assets/javascripts/rails_admin/jquery-ui.js
+++ b/app/assets/javascripts/rails_admin/jquery-ui.js
@@ -1,0 +1,3 @@
+//= require 'jquery-ui/effect'
+//= require 'jquery-ui/widgets/sortable'
+//= require 'jquery-ui/widgets/autocomplete'

--- a/app/assets/javascripts/rails_admin/jquery-ui.js.erb
+++ b/app/assets/javascripts/rails_admin/jquery-ui.js.erb
@@ -1,8 +1,0 @@
-<% require_asset "jquery-ui/effect" %>
-<% if Jquery::Ui::Rails::JQUERY_UI_VERSION >= '1.12' %>
-  <% require_asset "jquery-ui/widgets/sortable" %>
-  <% require_asset "jquery-ui/widgets/autocomplete" %>
-<% else %>
-  <% require_asset "jquery-ui/sortable" %>
-  <% require_asset "jquery-ui/autocomplete" %>
-<% end %>

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'builder', '~> 3.1'
   spec.add_dependency 'haml', '>= 4.0', '< 6'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
-  spec.add_dependency 'jquery-ui-rails', ['>= 5.0', '< 7']
+  spec.add_dependency 'jquery-ui-rails', ['>= 6.0', '< 7']
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'
   spec.add_dependency 'nested_form', '~> 0.3'
   spec.add_dependency 'rack-pjax', '>= 0.7'


### PR DESCRIPTION
Require rails-jquery-ui 6.0 (released Nov 29, 2016) which ships jQuery
UI 1.12.1 to allow simplifying by remove obsolete support.