### PR TITLE
Remove capitalization helper

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -1,13 +1,5 @@
 module RailsAdmin
   module ApplicationHelper
-    def capitalize_first_letter(wording)
-      return nil unless wording.present? && wording.is_a?(String)
-
-      wording = wording.dup
-      wording[0] = wording[0].mb_chars.capitalize.to_s
-      wording
-    end
-
     def authorized?(action_name, abstract_model = nil, object = nil)
       object = nil if object.try :new_record?
       action(action_name, abstract_model, object).try(:authorized?)
@@ -58,10 +50,10 @@ module RailsAdmin
       object = nil unless abstract_model && object.is_a?(abstract_model.model)
       action = RailsAdmin::Config::Actions.find(action.to_sym) if action.is_a?(Symbol) || action.is_a?(String)
 
-      capitalize_first_letter I18n.t(
+      I18n.t(
         "admin.actions.#{action.i18n_key}.#{label}",
-        model_label: model_config && model_config.label,
-        model_label_plural: model_config && model_config.label_plural,
+        model_label: model_config&.label,
+        model_label_plural: model_config&.label_plural,
         object_label: model_config && object.try(model_config.object_label_method),
       )
     end
@@ -76,7 +68,7 @@ module RailsAdmin
 
         label = navigation_label || t('admin.misc.navigation')
 
-        %(<li class='dropdown-header'>#{capitalize_first_letter label}</li>#{li_stack}) if li_stack.present?
+        %(<li class='dropdown-header'>#{label}</li>#{li_stack}) if li_stack.present?
       end.join.html_safe
     end
 
@@ -91,7 +83,7 @@ module RailsAdmin
         end.join.html_safe
         label ||= t('admin.misc.root_navigation')
 
-        %(<li class='dropdown-header'>#{capitalize_first_letter label}</li>#{li_stack}) if li_stack.present?
+        %(<li class='dropdown-header'>#{label}</li>#{li_stack}) if li_stack.present?
       end.join.html_safe
     end
 
@@ -112,7 +104,7 @@ module RailsAdmin
         level_class = " nav-level-#{level}" if level > 0
         nav_icon = node.navigation_icon ? %(<i class="#{node.navigation_icon}"></i>).html_safe : ''
         li = content_tag :li, data: {model: model_param} do
-          link_to nav_icon + capitalize_first_letter(node.label_plural), url, class: "pjax#{level_class}"
+          link_to nav_icon + node.label_plural, url, class: "pjax#{level_class}"
         end
         li + navigation(nodes_stack, nodes_stack.select { |n| n.parent.to_s == node.abstract_model.model_name }, level + 1)
       end.join.html_safe

--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -44,7 +44,7 @@ module RailsAdmin
       return if nested_field_association?(field, nested_in)
       @template.content_tag(:div, class: "form-group control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", id: "#{dom_id(field)}_field") do
         if field.label
-          label(field.method_name, capitalize_first_letter(field.label), class: 'col-sm-2 control-label') +
+          label(field.method_name, field.label, class: 'col-sm-2 control-label') +
             (field.nested_form ? field_for(field) : input_for(field))
         else
           field.nested_form ? field_for(field) : input_for(field)

--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -15,7 +15,7 @@
             - last_created = @most_recent_created[abstract_model.model.name]
             - active = last_created.try(:today?)
             %td
-              %span.show= link_to capitalize_first_letter(abstract_model.config.label_plural), index_path, class: 'pjax'
+              %span.show= link_to abstract_model.config.label_plural, index_path, class: 'pjax'
             %td
               - if last_created
                 = t "admin.misc.time_ago", time: time_ago_in_words(last_created), default: "#{time_ago_in_words(last_created)} #{t("admin.misc.ago")}"

--- a/app/views/rails_admin/main/export.html.haml
+++ b/app/views/rails_admin/main/export.html.haml
@@ -30,11 +30,11 @@
                   - polymorphic_type_column_name = @abstract_model.properties.detect {|p| field.association.foreign_type == p.name }.name
                   %label{for: "schema_#{list}_#{polymorphic_type_column_name}"}
                     = check_box_tag "schema[#{list}][]", polymorphic_type_column_name, true, { id: "schema_#{list}_#{polymorphic_type_column_name}" }
-                    = capitalize_first_letter(field.label) + " [type]"
+                    = field.label + " [type]"
                 - else
                   %label{for: "schema_#{list}_#{field.name}"}
                     = check_box_tag "schema[#{list}][]", field.name, true, { id: "schema_#{list}_#{field.name}" }
-                    = capitalize_first_letter(field.label)
+                    = field.label
 
     - visible_fields.select{ |f| f.association? && !f.association.polymorphic? }.each do |field|
       - fields = field.associated_model_config.export.with(controller: self.controller, view: self, object: (associated_model = field.associated_model_config.abstract_model.model).new).visible_fields.select{ |f| !f.association? }
@@ -49,7 +49,7 @@
                 .checkbox.col-sm-3
                   %label{for: "schema_include_#{field.name}_#{list}_#{associated_model_field.name}"}
                     = check_box_tag "schema[include][#{field.name}][#{list}][]", associated_model_field.name, true, { id: "schema_include_#{field.name}_#{list}_#{associated_model_field.name}" }
-                    = capitalize_first_letter(associated_model_field.label)
+                    = associated_model_field.label
 
   %fieldset
     %legend

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -35,7 +35,7 @@
           - else
             - ''
           %li
-            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-operator" => field.default_filter_operator, :"data-field-options" => field_options.html_safe, :"data-field-required" => field.required.to_s, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => field.try(:momentjs_format)}= capitalize_first_letter(field.label)
+            %a{href: '#', :"data-field-label" => field.label, :"data-field-name" => field.name, :"data-field-operator" => field.default_filter_operator, :"data-field-options" => field_options.html_safe, :"data-field-required" => field.required.to_s, :"data-field-type" => field.type, :"data-field-value" => "", :"data-field-datetimepicker-format" => field.try(:momentjs_format)}= field.label
 
 %style
   - properties.select{ |p| p.column_width.present? }.each do |property|
@@ -86,7 +86,7 @@
             - if property.sortable
               - sort_location = index_path params.except('sort_reverse').except('page').merge(sort: property.name).merge(selected && sort_reverse != "true" ? {sort_reverse: "true"} : {})
               - sort_direction = (sort_reverse == 'true' ? "headerSortUp" : "headerSortDown" if selected)
-            %th{class: "#{property.sortable && "header pjax" || nil} #{sort_direction if property.sortable && sort_direction} #{property.css_class} #{property.type_css_class}", :'data-href' => (property.sortable && sort_location), rel: "tooltip", title: "#{property.hint}"}= capitalize_first_letter(property.label)
+            %th{class: "#{property.sortable && "header pjax" || nil} #{sort_direction if property.sortable && sort_direction} #{property.css_class} #{property.type_css_class}", :'data-href' => (property.sortable && sort_location), rel: "tooltip", title: "#{property.hint}"}= property.label
           - if other_right
             %th.other.right.shrink= "..."
           - unless frozen_columns

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe RailsAdmin::ApplicationHelper, type: :helper do
         bc = helper.breadcrumb
         expect(bc).to match(/Dashboard/) # dashboard
         expect(bc).to match(/Teams/) # list
-        expect(bc).to match(/The avengers/) # show
+        expect(bc).to match(/the avengers/) # show
         expect(bc).to match(/Edit/) # current (edit)
       end
     end
@@ -283,7 +283,7 @@ RSpec.describe RailsAdmin::ApplicationHelper, type: :helper do
             navigation_label 'commentable'
           end
         end
-        expect(helper.main_navigation).to match(/(dropdown\-header).*(Commentable).*(Comments)/m)
+        expect(helper.main_navigation).to match(/(dropdown\-header).*(commentable).*(Comments)/m)
       end
 
       it 'nests in parent model' do


### PR DESCRIPTION
Added in https://github.com/sferik/rails_admin/commit/7f1033730dc948a12c86fd58e6a9e070f1b4dcfa, `#capitalize_first_letter` includes assumptions about letter order / casing for all strings, and may apply the wrong capitalization rules for some use cases / contexts (case-sensitive strings, different languages - related https://github.com/sferik/rails_admin/issues/2354, [StackOverflow Q/A](https://stackoverflow.com/questions/12169785/what-is-the-best-practice-to-capitalize-words-in-rails)).

Most of the use cases here are using translations, in which case the letter casing can / should be applied in the translations themselves. Other cases, such as rendering the value of `object_label_method`, will show the value as-is without transformation (as seen in the test updates). Cursory checks in the Dummy app show no changes to the UI.

My use case here involves the latter, where the object's label (case sensitive) in the breadcrumb navigation is capitalized and has led to some confusion.

The [CSS property `text-transform`](https://www.w3schools.com/cssref/pr_text_text-transform.asp) offers an alternative to achieve the same outcome, giving users of this library a way of applying letter-case logic in [theme overrides](https://github.com/sferik/rails_admin/wiki/Theming-and-customization).