### PR TITLE
Update `image?` check for file upload field types

### DIFF
--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -17,7 +17,8 @@ module RailsAdmin
 
           register_instance_option :image? do
             if value
-              value.filename.to_s.split('.').last =~ /jpg|jpeg|png|gif|svg/i
+              mime_type = Mime::Type.lookup_by_extension(value.filename.extension_without_delimiter)
+              mime_type.to_s.match?(/^image/)
             end
           end
 

--- a/lib/rails_admin/config/fields/types/dragonfly.rb
+++ b/lib/rails_admin/config/fields/types/dragonfly.rb
@@ -12,7 +12,8 @@ module RailsAdmin
           register_instance_option :image? do
             false unless value
             if abstract_model.model.new.respond_to?("#{name}_name")
-              bindings[:object].send("#{name}_name").to_s.split('.').last =~ /jpg|jpeg|png|gif/i
+              mime_type = Mime::Type.lookup_by_extension(bindings[:object].send("#{name}_name").to_s.split('.').last)
+              mime_type.to_s.match?(/^image/)
             else
               true # Dragonfly really is image oriented
             end

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -50,7 +50,8 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            (url = resource_url.to_s) && url.split('.').last =~ /jpg|jpeg|png|gif|svg/i
+            mime_type = Mime::Type.lookup_by_extension(resource_url.to_s.split('.').last)
+            mime_type.to_s.match?(/^image/)
           end
 
           register_instance_option :allowed_methods do

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -18,7 +18,8 @@ module RailsAdmin
 
             register_instance_option :image? do
               if value
-                value.filename.to_s.split('.').last =~ /jpg|jpeg|png|gif|svg/i
+                mime_type = Mime::Type.lookup_by_extension(value.filename.extension_without_delimiter)
+                mime_type.to_s.match?(/^image/)
               end
             end
 

--- a/lib/rails_admin/config/fields/types/multiple_file_upload.rb
+++ b/lib/rails_admin/config/fields/types/multiple_file_upload.rb
@@ -45,7 +45,8 @@ module RailsAdmin
             end
 
             register_instance_option :image? do
-              (url = resource_url.to_s) && url.split('.').last =~ /jpg|jpeg|png|gif|svg/i
+              mime_type = Mime::Type.lookup_by_extension(resource_url.to_s.split('.').last)
+              mime_type.to_s.match?(/^image/)
             end
 
             def resource_url(_thumb = false)

--- a/spec/rails_admin/config/fields/types/active_storage_spec.rb
+++ b/spec/rails_admin/config/fields/types/active_storage_spec.rb
@@ -17,11 +17,18 @@ RSpec.describe RailsAdmin::Config::Fields::Types::ActiveStorage do
   end
 
   describe '#image?' do
-    context 'when attachment is an image' do
-      let(:record) { FactoryBot.create :field_test, active_storage_asset: {io: StringIO.new('dummy'), filename: "test.jpg", content_type: "image/jpeg"} }
+    context 'configured Mime::Types' do
+      before { Mime::Type.register 'image/webp', :webp }
+      after { Mime::Type.unregister :webp }
 
-      it 'returns true' do
-        expect(field.image?).to be_truthy
+      %w[jpg jpeg png gif svg webp].each do |image_type_ext|
+        context "when attachment is a '#{image_type_ext}' file" do
+          let(:record) { FactoryBot.create :field_test, active_storage_asset: {io: StringIO.new('dummy'), filename: "test.#{image_type_ext}"} }
+
+          it 'returns true' do
+            expect(field.image?).to be_truthy
+          end
+        end
       end
     end
 


### PR DESCRIPTION
[Lookup the type ](https://apidock.com/rails/v6.0.0/Mime/Type/lookup_by_extension/class)via the [extension](https://apidock.com/rails/ActiveStorage/Filename/extension_without_delimiter), and match against 'image' types.

Rails provides a way to register custom mime types, allowing additional 'image' types to [be added to an Rails application](https://guides.rubyonrails.org/action_controller_overview.html#restful-downloads) without needing to maintain a list of specific filename extensions in `rails_admin`

ex. [`webp`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#webp) 

```ruby
# config/initializers/mime_types.rb
Mime::Type.register 'image/webp', :webp
```

Related update in Rails adding `webp` as a valid content type for `ActiveStorage` https://github.com/rails/rails/commit/2a0823ecbaeb3a6fbedc5cc31879d68fdf27d0cb 

Closes https://github.com/sferik/rails_admin/issues/3239