### PR TITLE
Remove `tins` lock for Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,6 @@ group :test do
   gem 'simplecov-lcov', require: false
   gem 'timecop', '>= 0.5'
 
-  platforms :ruby_19 do
-    gem 'tins', '~> 1.6.0', require: false
-  end
-
   # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
   gem 'tzinfo-data', platforms: %i(mingw mswin x64_mingw jruby)
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -53,10 +53,6 @@ group :test do
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem "kt-paperclip"
   gem "shrine", "~> 3.0"
-
-  platforms :ruby_19 do
-    gem "tins", "~> 1.6.0", require: false
-  end
 end
 
 group :mongoid do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -53,10 +53,6 @@ group :test do
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem "kt-paperclip"
   gem "shrine", "~> 3.0"
-
-  platforms :ruby_19 do
-    gem "tins", "~> 1.6.0", require: false
-  end
 end
 
 group :mongoid do

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -47,10 +47,6 @@ group :test do
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
   gem "kt-paperclip"
   gem "shrine", "~> 3.0"
-
-  platforms :ruby_19 do
-    gem "tins", "~> 1.6.0", require: false
-  end
 end
 
 gemspec path: "../"


### PR DESCRIPTION
Added in https://github.com/sferik/rails_admin/commit/e76440ebd15011f0a636b9dcc8d3cf618f567d56, support for Ruby < 2.1 was dropped [a while ago](https://github.com/sferik/rails_admin/blob/master/CHANGELOG.md#100rc---2016-07-18).